### PR TITLE
new entries from thesis

### DIFF
--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-11 21:29:34 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-11 21:57:58 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{KurbZack08,
+	Author = {Kurby, C A and Zacks, J M},
+	Date-Added = {2019-05-11 21:57:04 -0400},
+	Date-Modified = {2019-05-11 21:57:58 -0400},
+	Journal = {Trends in Cognitive Science},
+	Number = {2},
+	Pages = {72-79},
+	Title = {Segmentation in the perception of memory and events},
+	Volume = {12},
+	Year = {2008}}
 
 @article{BaysEtal11,
 	Author = {Bays, P M and Gorgoraptis, N and Wee, N and Marshall, L and Husain, M},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-13 18:56:30 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-13 22:46:33 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{TigaEtal16,
+	Author = {Tiganj, Z and Jung, M W and Kim, J and Howard, M W},
+	Date-Added = {2019-05-13 22:45:40 -0400},
+	Date-Modified = {2019-05-13 22:46:33 -0400},
+	Journal = {Cerebral Cortex},
+	Number = {12},
+	Pages = {5663-5671},
+	Title = {Sequential firing codes for time in rodent medial prefrontal cortex},
+	Volume = {27},
+	Year = {2016}}
 
 @article{TompEtal15,
 	Author = {Tompary, A and Duncan, K and Davachi, L},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-13 02:17:38 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-13 02:18:50 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -122,9 +122,9 @@
 	Year = {2013}}
 
 @article{RaicEtal01,
-	Author = {Raichle, M E, and MacLeod, A M and Snyder, A Z and Powers, W J and Gusnard, D A and Shulman, G L},
+	Author = {Raichle, M E and MacLeod, A M and Snyder, A Z and Powers, W J and Gusnard, D A and Shulman, G L},
 	Date-Added = {2019-05-13 02:10:35 -0400},
-	Date-Modified = {2019-05-13 02:14:12 -0400},
+	Date-Modified = {2019-05-13 02:18:50 -0400},
 	Journal = {Proceedings of the National Academy of Sciences},
 	Number = {2},
 	Pages = {676-682},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-12 17:48:59 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-12 17:52:51 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{WimbEtal11,
+	Author = {Wimber, M and Schott, B H and Wendler, F and Seidenberg, C I and Behnisch, G and Macharadze, T and B\"{a}uml, K-H T and Richardson-Klavehn, A},
+	Date-Added = {2019-05-12 17:50:48 -0400},
+	Date-Modified = {2019-05-12 17:52:51 -0400},
+	Journal = {Translational Psychiatry},
+	Number = {7},
+	Pages = {e15},
+	Title = {Prefrontal dopamine and the dynamic control of human long-term memory},
+	Volume = {1},
+	Year = {2011}}
 
 @article{WimbEtal09,
 	Author = {Wimber, M and Rutschmann, R M and Greenlee, M W and B\"{a}uml, K-H},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-08 19:35:24 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-08 19:38:54 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,16 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{SweeEtal14,
+	Author = {Sweegers, C C G and Takashima, A and Fernandez, G and Talamini, L M},
+	Date-Added = {2019-05-08 23:37:27 +0000},
+	Date-Modified = {2019-05-08 23:38:54 +0000},
+	Journal = {Neuroimage},
+	Pages = {138-146},
+	Title = {Neural mechanisms supporting the extraction of general knowledge across episodic memories},
+	Volume = {87},
+	Year = {2014}}
 
 @article{RangEtal04b,
 	Author = {Ranganath, C and Yonelinas, A P and Cohen, M X and Dy, C J and Tom, S M and D'Esposito, M},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-09 02:30:37 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-11 21:29:34 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -8125,7 +8125,6 @@ Looking at the average shift from nominal to functional positions by nominal pos
 @article{LyonEtal08,
 	Abstract = {Visualizing spatial material is a cornerstone of human problem solving, but human visualization capacity is sharply limited. To investigate the sources of this limit, we developed a new task to measure visualization accuracy for verbally-described spatial paths (similar to street directions), and implemented a computational process model to perform it. In this model, developed within the Adaptive Control of Thought-Rational (ACT-R) architecture, visualization capacity is limited by three mechanisms. Two of these (associative interference and decay) are longstanding characteristics of ACT-R's declarative memory. A third (spatial interference) is a new mechanism motivated by spatial proximity effects in our data. We tested the model in two experiments, one with parameter-value fitting, and a replication without further fitting. Correspondence between model and data was close in both experiments, suggesting that the model may be useful for understanding why visualizing new, complex spatial material is so difficult.},
 	Author = {Lyon, Don R and Gunzelmann, Glenn and Gluck, Kevin A},
-	Bdsk-File-1 = {YnBsaXN0MDDSAQIDBFxyZWxhdGl2ZVBhdGhZYWxpYXNEYXRhXxAeMjAwOC1seW9uX2d1bnplbG1hbm5fZ2x1Y2sucGRmTxEB4gAAAAAB4gACAAANbm91dmVhdU1hY1BybwAAAAAAAAAAAAAAAAAAyedG5EgrAAADEilwHjIwMDgtbHlvbl9ndW56ZWxtYW5uX2dsdWNrLnBkZgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIjVzJTH5YAAAAAAAAAAAAAQACAAAJIAAAAAAAAAAAAAAAAAAAAAhtYWdlbGxhbgAQAAgAAMnnfyQAAAARAAgAAMlMxKgAAAABABADEilwAAjFJwAIe3AAAJigAAIAVW5vdXZlYXVNYWNQcm86VXNlcnM6AHJvYmVydHNla3VsZXI6AERyb3Bib3g6AG1hZ2VsbGFuOgAyMDA4LWx5b25fZ3VuemVsbWFubl9nbHVjay5wZGYAAA4APgAeADIAMAAwADgALQBsAHkAbwBuAF8AZwB1AG4AegBlAGwAbQBhAG4AbgBfAGcAbAB1AGMAawAuAHAAZABmAA8AHAANAG4AbwB1AHYAZQBhAHUATQBhAGMAUAByAG8AEgBDVXNlcnMvcm9iZXJ0c2VrdWxlci9Ecm9wYm94L21hZ2VsbGFuLzIwMDgtbHlvbl9ndW56ZWxtYW5uX2dsdWNrLnBkZgAAEwABLwAAFQACABT//wAAAAgADQAaACQARQAAAAAAAAIBAAAAAAAAAAUAAAAAAAAAAAAAAAAAAAIr},
 	Date-Added = {2014-04-04 16:37:02 +0000},
 	Date-Modified = {2014-04-04 16:37:02 +0000},
 	Journal = {Cognitive Psychology},
@@ -8139,6 +8138,7 @@ Looking at the average shift from nominal to functional positions by nominal pos
 	Title = {A computational model of spatial visualization capacity},
 	Volume = {57},
 	Year = {2008},
+	Bdsk-File-1 = {YnBsaXN0MDDSAQIDBFxyZWxhdGl2ZVBhdGhZYWxpYXNEYXRhXxAeMjAwOC1seW9uX2d1bnplbG1hbm5fZ2x1Y2sucGRmTxEB4gAAAAAB4gACAAANbm91dmVhdU1hY1BybwAAAAAAAAAAAAAAAAAAyedG5EgrAAADEilwHjIwMDgtbHlvbl9ndW56ZWxtYW5uX2dsdWNrLnBkZgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIjVzJTH5YAAAAAAAAAAAAAQACAAAJIAAAAAAAAAAAAAAAAAAAAAhtYWdlbGxhbgAQAAgAAMnnfyQAAAARAAgAAMlMxKgAAAABABADEilwAAjFJwAIe3AAAJigAAIAVW5vdXZlYXVNYWNQcm86VXNlcnM6AHJvYmVydHNla3VsZXI6AERyb3Bib3g6AG1hZ2VsbGFuOgAyMDA4LWx5b25fZ3VuemVsbWFubl9nbHVjay5wZGYAAA4APgAeADIAMAAwADgALQBsAHkAbwBuAF8AZwB1AG4AegBlAGwAbQBhAG4AbgBfAGcAbAB1AGMAawAuAHAAZABmAA8AHAANAG4AbwB1AHYAZQBhAHUATQBhAGMAUAByAG8AEgBDVXNlcnMvcm9iZXJ0c2VrdWxlci9Ecm9wYm94L21hZ2VsbGFuLzIwMDgtbHlvbl9ndW56ZWxtYW5uX2dsdWNrLnBkZgAAEwABLwAAFQACABT//wAAAAgADQAaACQARQAAAAAAAAIBAAAAAAAAAAUAAAAAAAAAAAAAAAAAAAIr},
 	Bdsk-Url-1 = {http://dx.doi.org/10.1016/j.cogpsych.2007.12.003}}
 
 @article{RollKesn06,
@@ -11223,17 +11223,15 @@ A second exp found very similar results where items were not actually updated - 
 	Volume = {47},
 	Year = {2009}}
 
-@inbook{RaoHowa08,
+@inproceedings{RaoHowa08,
 	Author = {Rao, V. A. and Howard, M. W.},
-	Chapter = {Retrieved context and the discovery of semantic structure},
+	Booktitle = {Advances in Neural Information Processing Systems},
 	Date-Added = {2014-04-04 16:37:02 +0000},
-	Date-Modified = {2014-04-04 16:37:04 +0000},
+	Date-Modified = {2019-05-11 21:29:34 -0400},
 	Editor = {J.C. Platt and D. Koller and Y. Singer and S. Roweis},
-	Owner = {per},
-	Pages = {1193},
+	Pages = {1193-1200},
 	Publisher = {MIT Press: Cambridge, MA.},
-	Timestamp = {2008.06.13},
-	Title = {Advances in Neural Information Processing Systems},
+	Title = {Retrieved context and the discovery of semantic structure},
 	Year = {2008}}
 
 @article{GrosLoza00,

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-11 21:57:58 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-11 22:04:24 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{SpeeEtal03,
+	Author = {Speer, N K and Swallow, K M and Zacks, J M},
+	Date-Added = {2019-05-11 22:03:06 -0400},
+	Date-Modified = {2019-05-11 22:04:24 -0400},
+	Journal = {Cognitive, Affective \& Behavioral Neuroscience},
+	Number = {4},
+	Pages = {335-345},
+	Title = {Activation of human motion processing areas during event perception},
+	Volume = {3},
+	Year = {2003}}
 
 @article{KurbZack08,
 	Author = {Kurby, C A and Zacks, J M},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-08 22:47:06 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-08 23:08:29 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{TseEtal07,
+	Author = {Tse, D and Langston, R F and Kakeyama, M and Bethus, I and Spooner, P A and Wood, E R and Witter, M P and Morris, R G M},
+	Date-Added = {2019-05-09 03:06:24 +0000},
+	Date-Modified = {2019-05-09 03:08:28 +0000},
+	Journal = {Science},
+	Number = {5821},
+	Pages = {76-82},
+	Title = {Schemas and memory consolidation},
+	Volume = {316},
+	Year = {2007}}
 
 @article{BonnEtal12,
 	Author = {Bonnici, H M and Chadwick, M J and Lutti, A and Hassabis, D and Weiskopf, N and Maguire, E A},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-13 18:52:32 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-13 18:54:28 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,16 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{NazaReza13,
+	Author = {Nazari-Serenjeh, F and Rezayof, A},
+	Date-Added = {2019-05-13 18:53:15 -0400},
+	Date-Modified = {2019-05-13 18:54:28 -0400},
+	Journal = {Progress in Neuro-Psychopharmacology and Biological Psychiatry},
+	Pages = {54-61},
+	Title = {Cooperative interaction between the basolateral amygdala and ventral tegmental area modulates the consolidation of inhibitory avoidance memory},
+	Volume = {40},
+	Year = {2013}}
 
 @article{CastEtal19,
 	Author = {Castillo D{\'\i}az, F and Hernandez, M A and Capell{\'a}, T and Medina, J H},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-13 03:21:39 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-13 17:02:36 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{PlonEtal00,
+	Author = {Ploner, C J and Gaymard, B M and Rivaud-P{\'e}choux, S and Baulac, M and Cl{\'e}menceau, S and Samson, S and Pierrot-Deseilligny, C},
+	Date-Added = {2019-05-13 17:00:39 -0400},
+	Date-Modified = {2019-05-13 17:02:36 -0400},
+	Journal = {Cerebral Cortex},
+	Number = {12},
+	Pages = {1211-1216},
+	Title = {Lesions affecting the parahippocampal cortex yield spatial memory deficits in humans},
+	Volume = {10},
+	Year = {2000}}
 
 @article{HumpEtal07,
 	Author = {Humphries, C and Binder, J R and Medler, D A and Liebenthal, E},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-13 17:02:36 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-13 17:06:22 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -132,9 +132,15 @@
 	Volume = {36},
 	Year = {2007}}
 
-@article{cite-key,
+@article{OchoEtal17,
+	Author = {Ochoa, J G and Hentgarden, D and Paulzak, A and Ogden, M and Pryson, R and Lamla, M and Rusyniak, W G},
 	Date-Added = {2019-05-13 03:20:44 -0400},
-	Date-Modified = {2019-05-13 03:20:44 -0400}}
+	Date-Modified = {2019-05-13 17:06:22 -0400},
+	Journal = {Epilepsy \& Behavior},
+	Pages = {17-22},
+	Title = {Subtle pathological changes in neocortical temporal lobe epilepsy},
+	Volume = {71},
+	Year = {017}}
 
 @article{XiaoEtal05,
 	Author = {Xiao, Z and Zhang, J X and Wang, X and Wu, R and Hu, X and Weng, X and Tan, L H},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-13 18:54:28 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-13 18:56:30 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{TompEtal15,
+	Author = {Tompary, A and Duncan, K and Davachi, L},
+	Date-Added = {2019-05-13 18:55:19 -0400},
+	Date-Modified = {2019-05-13 18:56:30 -0400},
+	Journal = {Journal of Neuroscience},
+	Number = {19},
+	Pages = {7326-7331},
+	Title = {Consolidation of associative and item memory is related to post-encoding functional connectivity between the ventral tegmental area and different medial temporal lobe subregions during an unrelated task},
+	Volume = {35},
+	Year = {2015}}
 
 @article{NazaReza13,
 	Author = {Nazari-Serenjeh, F and Rezayof, A},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-13 03:10:17 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-13 03:12:05 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{HensEtal02,
+	Author = {Henson, R N A and Price, C J and Rugg, M D and Turner, R and Friston, K J},
+	Date-Added = {2019-05-13 03:11:14 -0400},
+	Date-Modified = {2019-05-13 03:12:04 -0400},
+	Journal = {Neuroimage},
+	Number = {1},
+	Pages = {83-97},
+	Title = {Detecting latency differences in event-related BOLD responses: application to words versus nonwords and initial versus repeated face presentations},
+	Volume = {15},
+	Year = {2002}}
 
 @article{BaumEtal02,
 	Author = {Baumgaertner, A and Weiller, C and B{\"{u}}chel, C},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-08 19:38:54 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-08 19:41:04 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -134,8 +134,8 @@
 @article{WiltSilv07,
 	Author = {Wiltgen, B J and Silva, A J},
 	Date-Added = {2019-05-08 23:27:05 +0000},
-	Date-Modified = {2019-05-08 23:28:10 +0000},
-	Journal = {Learning & Memory},
+	Date-Modified = {2019-05-08 23:41:04 +0000},
+	Journal = {Learning \& Memory},
 	Number = {4},
 	Pages = {313-317},
 	Title = {Memory for context becomes less specific with time},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-13 02:18:50 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-13 02:43:42 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{McKiEtal03,
+	Author = {McKiernan, K A, Kaufman, J N and Kucera-Thompson, J and Binder, J R},
+	Date-Added = {2019-05-13 02:42:38 -0400},
+	Date-Modified = {2019-05-13 02:43:42 -0400},
+	Journal = {Journal of Cognitive Neuroscience},
+	Number = {3},
+	Pages = {394-408},
+	Title = {A parametric manipulation of factors affecting task-induced deactivation in functional neuroimaging},
+	Volume = {15},
+	Year = {2003}}
 
 @article{NakaEtal13,
 	Author = {Nakano, T and Kato, M and Morito, Y and Itoi, S and Kitazawa, S},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-12 15:41:44 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-12 16:13:53 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{AndeEtal94,
+	Author = {Anderson, M C and Bjork, R A and Bjork, E L},
+	Date-Added = {2019-05-12 16:12:59 -0400},
+	Date-Modified = {2019-05-12 16:13:50 -0400},
+	Journal = {Journal of Experimental Psychology: Learning, Memory, and Cognition},
+	Number = {5},
+	Pages = {1063},
+	Title = {Remembering can cause forgetting: retrieval dynamics in long-term memory.},
+	Volume = {20},
+	Year = {1994}}
 
 @article{Rebe10,
 	Author = {Reber, P J},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-08 23:08:29 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-08 23:12:06 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,21 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{TseEtal11,
+	Author = {Tse, D and Takeuchi, T and Kakeyama, M and Kajii, Y and Okuno, H and Tohyama, C and Bito, H and Morris, R G M},
+	Date-Added = {2019-05-09 03:10:41 +0000},
+	Date-Modified = {2019-05-09 03:12:06 +0000},
+	Journal = {Science},
+	Number = {6044},
+	Pages = {891-895},
+	Title = {Schema-dependent gene activation and memory encoding in neocortex},
+	Volume = {333},
+	Year = {2011}}
+
+@article{cite-key,
+	Date-Added = {2019-05-09 03:10:36 +0000},
+	Date-Modified = {2019-05-09 03:10:36 +0000}}
 
 @article{TseEtal07,
 	Author = {Tse, D and Langston, R F and Kakeyama, M and Bethus, I and Spooner, P A and Wood, E R and Witter, M P and Morris, R G M},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-13 02:43:42 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-13 02:46:15 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{TeasEtal95,
+	Author = {Teasdale, J D and Dritschel, B H and Taylor, M J and Proctor, L and Lloyd, C A and Nimmo-Smith, I and Baddeley, A D},
+	Date-Added = {2019-05-13 02:44:28 -0400},
+	Date-Modified = {2019-05-13 02:46:15 -0400},
+	Journal = {Memory \& Cognition},
+	Number = {5},
+	Pages = {551-559},
+	Title = {Stimulus-independent thought depends on central executive resources},
+	Volume = {23},
+	Year = {1995}}
 
 @article{McKiEtal03,
 	Author = {McKiernan, K A, Kaufman, J N and Kucera-Thompson, J and Binder, J R},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-12 17:52:51 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-13 01:30:05 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{RishEtal13,
+	Author = {Rishel, C A and Huang, G and Freedman, D J},
+	Date-Added = {2019-05-13 01:29:06 -0400},
+	Date-Modified = {2019-05-13 01:30:05 -0400},
+	Journal = {Neuron},
+	Number = {5},
+	Pages = {969-979},
+	Title = {Independent category and spatial encoding in parietal cortex},
+	Volume = {77},
+	Year = {2013}}
 
 @article{WimbEtal11,
 	Author = {Wimber, M and Schott, B H and Wendler, F and Seidenberg, C I and Behnisch, G and Macharadze, T and B\"{a}uml, K-H T and Richardson-Klavehn, A},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-12 17:43:04 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-12 17:48:59 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{WimbEtal09,
+	Author = {Wimber, M and Rutschmann, R M and Greenlee, M W and B\"{a}uml, K-H},
+	Date-Added = {2019-05-12 17:47:44 -0400},
+	Date-Modified = {2019-05-12 17:48:59 -0400},
+	Journal = {Journal of Cognitive Neuroscience},
+	Number = {3},
+	Pages = {538-549},
+	Title = {Retrieval from episodic memory: Neural mechanisms of interference resolution},
+	Volume = {21},
+	Year = {2009}}
 
 @article{WimbEtal08,
 	Author = {Wimber, M and B\"{a}uml, K-H and Bergstr{\"o}m, Z and Markopoulos, G and Heinze, H-J and Richardson-Klavehn, A},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-08 20:48:42 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-08 21:58:09 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,16 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{MadsEtal17,
+	Author = {Madsen, H B and Guerin, A A and Kim, J H},
+	Date-Added = {2019-05-09 01:56:58 +0000},
+	Date-Modified = {2019-05-09 01:58:07 +0000},
+	Journal = {Neurobiology of learning and memory},
+	Pages = {7-17},
+	Title = {Investigating the role of dopamine receptor-and parvalbumin-expressing cells in extinction of conditioned fear},
+	Volume = {145},
+	Year = {2017}}
 
 @article{SweeEtal14,
 	Author = {Sweegers, C C G and Takashima, A and Fernandez, G and Talamini, L M},
@@ -51557,15 +51567,6 @@ Suggest that the findings of increased theta power being associated with INCREAS
 	Title = {Retrieval-induced forgetting without competition: Testing the retrieval specificity assumption of the inhibition theory},
 	Volume = {40},
 	Year = {2011}}
-
-@inproceedings{RaoHowa07,
-	Author = {Rao, V. A. and Howard, M. W.},
-	Booktitle = {Advances in neural information processing systems},
-	Date-Added = {2014-04-04 16:37:02 +0000},
-	Date-Modified = {2019-05-09 00:48:42 +0000},
-	Pages = {1193-1200},
-	Title = {Retrieved context and the discovery of semantic structure},
-	Year = {2008}}
 
 @article{RatcMcKo94,
 	Author = {Ratcliff, R. and Mc{K}oon, G.},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-13 02:46:15 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-13 02:52:28 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -122,9 +122,9 @@
 	Year = {1995}}
 
 @article{McKiEtal03,
-	Author = {McKiernan, K A, Kaufman, J N and Kucera-Thompson, J and Binder, J R},
+	Author = {McKiernan, K A and Kaufman, J N and Kucera-Thompson, J and Binder, J R},
 	Date-Added = {2019-05-13 02:42:38 -0400},
-	Date-Modified = {2019-05-13 02:43:42 -0400},
+	Date-Modified = {2019-05-13 02:52:28 -0400},
 	Journal = {Journal of Cognitive Neuroscience},
 	Number = {3},
 	Pages = {394-408},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-13 03:18:11 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-13 03:20:18 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{XiaoEtal05,
+	Author = {Xiao, Z and Zhang, J X and Wang, X and Wu, R and Hu, X and Weng, X and Tan, L H},
+	Date-Added = {2019-05-13 03:19:11 -0400},
+	Date-Modified = {2019-05-13 03:20:18 -0400},
+	Journal = {Human Brain Mapping},
+	Number = {2},
+	Pages = {212-221},
+	Title = {Differential activity in left inferior frontal gyrus for pseudowords and real words: An event-related fMRI study on auditory lexical decision},
+	Volume = {25},
+	Year = {2005}}
 
 @article{BindEtal05,
 	Author = {Binder, J R and Medler, D A and Desai, R and Conant, L L and Liebenthal, E},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-08 19:28:11 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-08 19:34:24 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{RangEtal04,
+	Author = {Ranganath, C and Yonelinas, A P and Cohen, M X and Dy, C J and Tom, S M and D'Esposito, M},
+	Date-Added = {2019-05-08 23:32:47 +0000},
+	Date-Modified = {2019-05-08 23:34:24 +0000},
+	Journal = {Neuropsychologia},
+	Number = {1},
+	Pages = {2-13},
+	Title = {Dissociable correlates of recollection and familiarity within the medial temporal lobes},
+	Volume = {42},
+	Year = {2004}}
 
 @article{WiltSilv07,
 	Author = {Wiltgen, B J and Silva, A J},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-12 15:04:27 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-12 15:24:36 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{WangEtal03,
+	Author = {Wang, Y and Liu, D and Wang, Y},
+	Date-Added = {2019-05-12 15:23:48 -0400},
+	Date-Modified = {2019-05-12 15:24:36 -0400},
+	Journal = {Brain and Mind},
+	Number = {2},
+	Pages = {189-198},
+	Title = {Discovering the capacity of human memory},
+	Volume = {4},
+	Year = {2003}}
 
 @article{BartEtal15,
 	Author = {Bartol Jr, T M and Bromer, C and Kinney, J and Chirillo, M A and Bourne, J N and Harris, K M and Sejnowski, T J},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-08 23:32:57 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-08 23:37:46 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{OddoEtal10,
+	Author = {Oddo, S and Lux, S and Weiss, P H and Schwab, A and Welzer, H and Markowitsch, H J and Fink, G R},
+	Date-Added = {2019-05-09 03:35:00 +0000},
+	Date-Modified = {2019-05-09 03:37:46 +0000},
+	Journal = {Cortex},
+	Number = {1},
+	Pages = {29-39},
+	Title = {Specific role of medial prefrontal cortex in retrieving recent autobiographical memories: an fMRI study of young female subjects},
+	Volume = {2010},
+	Year = {2010}}
 
 @article{NikiLuo02,
 	Author = {Niki, K and Luo, J},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-13 17:06:22 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-13 17:45:22 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{TambEtal10,
+	Author = {Tambini, A and Ketz, N and Davachi, L},
+	Date-Added = {2019-05-13 17:44:33 -0400},
+	Date-Modified = {2019-05-13 17:45:22 -0400},
+	Journal = {Neuron},
+	Number = {2},
+	Pages = {280-290},
+	Title = {Enhanced brain correlations during rest are related to memory for recent experiences},
+	Volume = {65},
+	Year = {2010}}
 
 @article{PlonEtal00,
 	Author = {Ploner, C J and Gaymard, B M and Rivaud-P{\'e}choux, S and Baulac, M and Cl{\'e}menceau, S and Samson, S and Pierrot-Deseilligny, C},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-08 22:40:52 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-08 22:47:06 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{BonnEtal12,
+	Author = {Bonnici, H M and Chadwick, M J and Lutti, A and Hassabis, D and Weiskopf, N and Maguire, E A},
+	Date-Added = {2019-05-09 02:45:13 +0000},
+	Date-Modified = {2019-05-09 02:47:06 +0000},
+	Journal = {Journal of Neuroscience},
+	Number = {47},
+	Pages = {16982-16991},
+	Title = {Detecting representations of recent and remote autobiographical memories in vmPFC and hippocampus},
+	Volume = {32},
+	Year = {2012}}
 
 @article{TakaEtal07,
 	Author = {Takashima, A and Nieuwenhuis, I L C and Rijpkema, M and Petersson, K M and Jensen, O and Fernandez, G},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-08 19:34:24 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-08 19:35:24 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -110,10 +110,10 @@
 @string{vr = {Vision Research}}
 
 
-@article{RangEtal04,
+@article{RangEtal04b,
 	Author = {Ranganath, C and Yonelinas, A P and Cohen, M X and Dy, C J and Tom, S M and D'Esposito, M},
 	Date-Added = {2019-05-08 23:32:47 +0000},
-	Date-Modified = {2019-05-08 23:34:24 +0000},
+	Date-Modified = {2019-05-08 23:35:04 +0000},
 	Journal = {Neuropsychologia},
 	Number = {1},
 	Pages = {2-13},
@@ -33194,10 +33194,10 @@ Significant Because: This reflects my personal biases as RIF was important in my
 	Volume = {16},
 	Year = {1993}}
 
-@article{RangEtal04,
+@article{RangEtal04a,
 	Author = {Ranganath, C. and Cohen, M. X. and Dam, C. and {D'E}sposito, M.},
 	Date-Added = {2014-04-04 16:37:02 +0000},
-	Date-Modified = {2014-04-04 16:37:16 +0000},
+	Date-Modified = {2019-05-08 23:35:24 +0000},
 	Journal = {Journal of Neuroscience},
 	Number = {16},
 	Owner = {mvugt},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-13 01:59:50 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-13 02:04:11 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{McKiEtal06,
+	Author = {McKiernan, K A and D'angelo, B R and Kaufman, J N and Binder, J R},
+	Date-Added = {2019-05-13 02:02:28 -0400},
+	Date-Modified = {2019-05-13 02:04:11 -0400},
+	Journal = {Neuroimage},
+	Number = {4},
+	Pages = {1185-1191},
+	Title = {Interrupting the ``stream of consciousness'': an fMRI investigation},
+	Volume = {29},
+	Year = {2006}}
 
 @article{BindEtal09,
 	Author = {Binder, J R and Desai, R H and Graves, W W and Conant, L L},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-08 21:58:09 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-08 22:40:52 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,28 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{TakaEtal07,
+	Author = {Takashima, A and Nieuwenhuis, I L C and Rijpkema, M and Petersson, K M and Jensen, O and Fernandez, G},
+	Date-Added = {2019-05-09 02:39:15 +0000},
+	Date-Modified = {2019-05-09 02:40:52 +0000},
+	Journal = {Learning \& Memory},
+	Number = {7},
+	Pages = {472-479},
+	Title = {Memory trace stabilization leads to large-scale changes in the retrieval network: a functional MRI study on associative memory},
+	Volume = {14},
+	Year = {2007}}
+
+@article{NieuTaka11,
+	Author = {Nieuwenhuis, I L C and Takashima, A},
+	Date-Added = {2019-05-09 02:02:57 +0000},
+	Date-Modified = {2019-05-09 02:04:10 +0000},
+	Journal = {Behavioural brain research},
+	Number = {2},
+	Pages = {325-334},
+	Title = {The role of the ventromedial prefrontal cortex in memory consolidation},
+	Volume = {218},
+	Year = {2011}}
 
 @article{MadsEtal17,
 	Author = {Madsen, H B and Guerin, A A and Kim, J H},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-13 02:11:47 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-13 02:14:12 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -110,10 +110,10 @@
 @string{vr = {Vision Research}}
 
 
-@article{RaicEtal13,
+@article{RaicEtal01,
 	Author = {Raichle, M E, and MacLeod, A M and Snyder, A Z and Powers, W J and Gusnard, D A and Shulman, G L},
 	Date-Added = {2019-05-13 02:10:35 -0400},
-	Date-Modified = {2019-05-13 02:11:47 -0400},
+	Date-Modified = {2019-05-13 02:14:12 -0400},
 	Journal = {Proceedings of the National Academy of Sciences},
 	Number = {2},
 	Pages = {676-682},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-13 18:47:14 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-13 18:52:32 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,15 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{CastEtal19,
+	Author = {Castillo D{\'\i}az, F and Hernandez, M A and Capell{\'a}, T and Medina, J H},
+	Date-Added = {2019-05-13 18:48:03 -0400},
+	Date-Modified = {2019-05-13 18:52:32 -0400},
+	Journal = {Molecular Neurobiology},
+	Pages = {1-12},
+	Title = {Dopamine Neurotransmission in the Ventral Tegmental Area Promotes Active Forgetting of Cocaine-Associated Memory},
+	Year = {2019}}
 
 @article{KitaEtal17,
 	Author = {Kitamura, T and Ogawa, S K and Roy, D S and Okuyama, T and Morrissey, M D and Smith, L M and Redondo, R L and Tonegawa, S},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-08 23:13:53 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-08 23:29:22 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{MaguEtal01,
+	Author = {Maguire, E A and Henson, R N A and Mummery, C J and Frith, C D},
+	Date-Added = {2019-05-09 03:22:27 +0000},
+	Date-Modified = {2019-05-09 03:29:22 +0000},
+	Journal = {Neuroreport},
+	Number = {3},
+	Pages = {441-444},
+	Title = {Activity in prefrontal cortex, not hippocampus, varies parametrically with the increasing remoteness of memories},
+	Volume = {12},
+	Year = {2001}}
 
 @article{TseEtal11,
 	Author = {Tse, D and Takeuchi, T and Kakeyama, M and Kajii, Y and Okuno, H and Tohyama, C and Bito, H and Morris, R G M},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-13 22:46:33 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-13 22:50:23 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{Howa18,
+	Author = {Howard, M W},
+	Date-Added = {2019-05-13 22:48:42 -0400},
+	Date-Modified = {2019-05-13 22:50:23 -0400},
+	Journal = {Trends in Cognitive Science},
+	Number = {2},
+	Pages = {124-136},
+	Title = {Memory as perception of the past: compressed time in mind and brain},
+	Volume = {22},
+	Year = {2018}}
 
 @article{TigaEtal16,
 	Author = {Tiganj, Z and Jung, M W and Kim, J and Howard, M W},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-12 14:58:05 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-12 15:04:27 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,16 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{BartEtal15,
+	Author = {Bartol Jr, T M and Bromer, C and Kinney, J and Chirillo, M A and Bourne, J N and Harris, K M and Sejnowski, T J},
+	Date-Added = {2019-05-12 15:02:12 -0400},
+	Date-Modified = {2019-05-12 15:04:27 -0400},
+	Journal = {eLife},
+	Pages = {e10778},
+	Title = {Nanoconnectomic upper bound on the variability of synaptic plasticity},
+	Volume = {4},
+	Year = {2015}}
 
 @article{WimbEtal15,
 	Author = {Wimber, M and Alink, A and Charest, I and Kriegeskorte, N and Anderson, M C},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-13 02:04:11 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-13 02:11:47 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{RaicEtal13,
+	Author = {Raichle, M E, and MacLeod, A M and Snyder, A Z and Powers, W J and Gusnard, D A and Shulman, G L},
+	Date-Added = {2019-05-13 02:10:35 -0400},
+	Date-Modified = {2019-05-13 02:11:47 -0400},
+	Journal = {Proceedings of the National Academy of Sciences},
+	Number = {2},
+	Pages = {676-682},
+	Title = {A default mode of brain function},
+	Volume = {98},
+	Year = {2001}}
 
 @article{McKiEtal06,
 	Author = {McKiernan, K A and D'angelo, B R and Kaufman, J N and Binder, J R},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-13 03:13:34 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-13 03:15:08 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{RissEtal03,
+	Author = {Rissman, J and Eliassen, J C and Blumstein, S E},
+	Date-Added = {2019-05-13 03:14:26 -0400},
+	Date-Modified = {2019-05-13 03:15:08 -0400},
+	Journal = {Journal of Cognitive Neuroscience},
+	Number = {8},
+	Pages = {1160-1175},
+	Title = {An event-related fMRI investigation of implicit semantic priming},
+	Volume = {15},
+	Year = {2003}}
 
 @article{MechEtal03,
 	Author = {Mechelli, A and Gorno-Tempini, M L and Price, C J},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-13 01:56:28 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-13 01:59:50 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{BindEtal09,
+	Author = {Binder, J R and Desai, R H and Graves, W W and Conant, L L},
+	Date-Added = {2019-05-13 01:58:43 -0400},
+	Date-Modified = {2019-05-13 01:59:50 -0400},
+	Journal = {Cerebral Cortex},
+	Number = {12},
+	Pages = {2767-2769},
+	Title = {Where is the semantic system? A critical review and meta-analysis of 120 functional neuroimaging studies},
+	Volume = {19},
+	Year = {2009}}
 
 @article{Raic06,
 	Author = {Raichle, M E},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-13 03:15:08 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-13 03:18:11 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,28 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{BindEtal05,
+	Author = {Binder, J R and Medler, D A and Desai, R and Conant, L L and Liebenthal, E},
+	Date-Added = {2019-05-13 03:17:03 -0400},
+	Date-Modified = {2019-05-13 03:18:11 -0400},
+	Journal = {Neuroimage},
+	Number = {3},
+	Pages = {677-693},
+	Title = {Some neurophysiological constraints on models of word naming},
+	Volume = {27},
+	Year = {2005}}
+
+@article{IschEtal04,
+	Author = {Ischelbeck, A and Indefrey, P and Usui, N and Nose, I and Hellwig, F and Taira, M},
+	Date-Added = {2019-05-13 03:15:44 -0400},
+	Date-Modified = {2019-05-13 03:16:43 -0400},
+	Journal = {Journal of Cognitive Neuroscience},
+	Number = {5},
+	Pages = {727-741},
+	Title = {Reading in a regular orthography: an FMRI study investigating the role of visual familiarity},
+	Volume = {16},
+	Year = {2004}}
 
 @article{RissEtal03,
 	Author = {Rissman, J and Eliassen, J C and Blumstein, S E},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-12 15:24:36 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-12 15:28:49 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{BradEtal08,
+	Author = {Brady, T F and Konkle, T and Alvarez, G A and Oliva, A},
+	Date-Added = {2019-05-12 15:27:55 -0400},
+	Date-Modified = {2019-05-12 15:28:49 -0400},
+	Journal = {Proceedings of the National Academy of Sciences},
+	Number = {38},
+	Pages = {14325-14329},
+	Title = {Visual long-term memory has a massive storage capacity for object details},
+	Volume = {105},
+	Year = {2008}}
 
 @article{WangEtal03,
 	Author = {Wang, Y and Liu, D and Wang, Y},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-08 23:37:46 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-08 23:40:15 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{BarrEtal18,
+	Author = {Barry, D N and Chadwick, M J and Maguire, E A},
+	Date-Added = {2019-05-09 03:38:29 +0000},
+	Date-Modified = {2019-05-09 03:40:15 +0000},
+	Journal = {PLoS Biology},
+	Number = {7},
+	Pages = {e2005479},
+	Title = {Nonmonotonic recruitment of ventromedial prefrontal cortex during remote memory recall},
+	Volume = {16},
+	Year = {2018}}
 
 @article{OddoEtal10,
 	Author = {Oddo, S and Lux, S and Weiss, P H and Schwab, A and Welzer, H and Markowitsch, H J and Fink, G R},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-12 15:35:30 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-12 15:41:44 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,16 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{Rebe10,
+	Author = {Reber, P J},
+	Date-Added = {2019-05-12 15:40:48 -0400},
+	Date-Modified = {2019-05-12 15:41:43 -0400},
+	Journal = {Scientific American},
+	Month = {May},
+	Title = {What is the memory capacity of the human brain},
+	Volume = {4},
+	Year = {2010}}
 
 @article{PereNiez86,
 	Author = {Peretto, P and Niez, J},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-13 22:50:23 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-14 00:40:14 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,15 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{SilvEtal19,
+	Author = {Silva, M and Baldassano, C and Fuentemilla, L},
+	Date-Added = {2019-05-14 00:33:35 -0400},
+	Date-Modified = {2019-05-14 00:40:14 -0400},
+	Journal = {BioRxiv},
+	Pages = {511782},
+	Title = {Rapid memory reactivation at movie event boundaries promotes episodic encoding},
+	Year = {2019}}
 
 @article{Howa18,
 	Author = {Howard, M W},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-12 15:28:49 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-12 15:35:30 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{PereNiez86,
+	Author = {Peretto, P and Niez, J},
+	Date-Added = {2019-05-12 15:34:28 -0400},
+	Date-Modified = {2019-05-12 15:35:30 -0400},
+	Journal = {Biological Cybernetics},
+	Number = {1},
+	Pages = {53-63},
+	Title = {Long term memory storage capacity of multiconnected neural networks},
+	Volume = {54},
+	Year = {1986}}
 
 @article{BradEtal08,
 	Author = {Brady, T F and Konkle, T and Alvarez, G A and Oliva, A},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-14 00:40:14 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-15 10:54:08 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -2660,9 +2660,10 @@
 	Year = {1990},
 	Bdsk-Url-1 = {http://dx.doi.org/10.1016/0197-4580(90)90545-B}}
 
-@article{AlyTurk17,
+@incollection{AlyTurk17,
 	Author = {Aly, Mariam and Turk-Browne, Nicholas B},
 	Booktitle = {The hippocampus from cells to systems},
+	Date-Modified = {2019-05-15 10:54:05 -0400},
 	Pages = {369--403},
 	Publisher = {Springer},
 	Title = {How hippocampal memory shapes, and is shaped by, attention},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-13 02:52:28 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-13 03:10:17 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{BaumEtal02,
+	Author = {Baumgaertner, A and Weiller, C and B{\"{u}}chel, C},
+	Date-Added = {2019-05-13 03:09:20 -0400},
+	Date-Modified = {2019-05-13 03:10:17 -0400},
+	Journal = {Neuroimage},
+	Number = {3},
+	Pages = {736-745},
+	Title = {Event-related fMRI reveals cortical sites involved in contextual sentence integration},
+	Volume = {16},
+	Year = {2002}}
 
 @article{TeasEtal95,
 	Author = {Teasdale, J D and Dritschel, B H and Taylor, M J and Proctor, L and Lloyd, C A and Nimmo-Smith, I and Baddeley, A D},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-08 23:29:22 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-08 23:32:57 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{NikiLuo02,
+	Author = {Niki, K and Luo, J},
+	Date-Added = {2019-05-09 03:31:44 +0000},
+	Date-Modified = {2019-05-09 03:32:55 +0000},
+	Journal = {Journal of Cognitive Neuroscience},
+	Number = {3},
+	Pages = {500-507},
+	Title = {An fMRI study on the time-limited role of the medial temporal lobe in long-term topographical autobiographic memory},
+	Volume = {14},
+	Year = {2002}}
 
 @article{MaguEtal01,
 	Author = {Maguire, E A and Henson, R N A and Mummery, C J and Frith, C D},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-11 22:04:24 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-12 14:58:05 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{WimbEtal15,
+	Author = {Wimber, M and Alink, A and Charest, I and Kriegeskorte, N and Anderson, M C},
+	Date-Added = {2019-05-12 14:56:42 -0400},
+	Date-Modified = {2019-05-12 14:58:04 -0400},
+	Journal = {Nature Neuroscience},
+	Number = {4},
+	Pages = {582},
+	Title = {Retrieval induces adaptive forgetting of competing memories via cortical pattern suppression},
+	Volume = {18},
+	Year = {2015}}
 
 @article{SpeeEtal03,
 	Author = {Speer, N K and Swallow, K M and Zacks, J M},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-13 17:45:22 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-13 17:47:24 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{TambDava13,
+	Author = {Tambini, A and Davachi, L},
+	Date-Added = {2019-05-13 17:45:57 -0400},
+	Date-Modified = {2019-05-13 17:47:24 -0400},
+	Journal = {Proceedings of the National Academy of Sciences},
+	Number = {48},
+	Pages = {19591-19596},
+	Title = {Persistence of hippocampal multivoxel patterns into postencoding rest is related to memory},
+	Volume = {110},
+	Year = {2013}}
 
 @article{TambEtal10,
 	Author = {Tambini, A and Ketz, N and Davachi, L},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-13 02:14:12 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-13 02:17:38 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{NakaEtal13,
+	Author = {Nakano, T and Kato, M and Morito, Y and Itoi, S and Kitazawa, S},
+	Date-Added = {2019-05-13 02:16:48 -0400},
+	Date-Modified = {2019-05-13 02:17:38 -0400},
+	Journal = {Proceedings of the National Academy of Sciences},
+	Number = {2},
+	Pages = {702-706},
+	Title = {Blink-related momentary activation of the default mode network while viewing videos},
+	Volume = {110},
+	Year = {2013}}
 
 @article{RaicEtal01,
 	Author = {Raichle, M E, and MacLeod, A M and Snyder, A Z and Powers, W J and Gusnard, D A and Shulman, G L},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-12 17:39:54 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-12 17:43:04 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{WimbEtal08,
+	Author = {Wimber, M and B\"{a}uml, K-H and Bergstr{\"o}m, Z and Markopoulos, G and Heinze, H-J and Richardson-Klavehn, A},
+	Date-Added = {2019-05-12 17:40:30 -0400},
+	Date-Modified = {2019-05-12 17:43:04 -0400},
+	Journal = {Journal of Neuroscience},
+	Number = {50},
+	Pages = {13419-13427},
+	Title = {Neural markers of inhibition in human memory retrieval},
+	Volume = {28},
+	Year = {2008}}
 
 @article{KuhlEtal07,
 	Author = {Kuhl, B A and Dudukovic, N M and Kahn, I and Wagner, A D},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-13 03:12:05 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-13 03:13:34 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{MechEtal03,
+	Author = {Mechelli, A and Gorno-Tempini, M L and Price, C J},
+	Date-Added = {2019-05-13 03:12:53 -0400},
+	Date-Modified = {2019-05-13 03:13:34 -0400},
+	Journal = {Journal of Cognitive Neuroscience},
+	Number = {2},
+	Pages = {260-271},
+	Title = {Neuroimaging studies of word and pseudoword reading: consistencies, inconsistencies, and limitations},
+	Volume = {15},
+	Year = {2003}}
 
 @article{HensEtal02,
 	Author = {Henson, R N A and Price, C J and Rugg, M D and Turner, R and Friston, K J},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-08 18:32:44 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-08 19:28:11 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{WiltSilv07,
+	Author = {Wiltgen, B J and Silva, A J},
+	Date-Added = {2019-05-08 23:27:05 +0000},
+	Date-Modified = {2019-05-08 23:28:10 +0000},
+	Journal = {Learning & Memory},
+	Number = {4},
+	Pages = {313-317},
+	Title = {Memory for context becomes less specific with time},
+	Volume = {14},
+	Year = {2007}}
 
 @article{HuthEtal12,
 	Author = {Huth, A G and Nisimoto, S and Vu, A T and Gallant, J L},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-09 01:37:08 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-09 02:30:37 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{BaysEtal11,
+	Author = {Bays, P M and Gorgoraptis, N and Wee, N and Marshall, L and Husain, M},
+	Date-Added = {2019-05-09 06:28:21 +0000},
+	Date-Modified = {2019-05-09 06:30:35 +0000},
+	Journal = {Journal of Vision},
+	Number = {10},
+	Pages = {6},
+	Title = {Temporal dynamics of encoding, storage, and reallocation of visual working memory},
+	Volume = {11},
+	Year = {2011}}
 
 @article{BargThei85,
 	Author = {Bargh, John A and Thein, R D},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-13 01:53:10 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-13 01:56:28 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{Raic06,
+	Author = {Raichle, M E},
+	Date-Added = {2019-05-13 01:55:36 -0400},
+	Date-Modified = {2019-05-13 01:56:28 -0400},
+	Journal = {Science},
+	Number = {5803},
+	Pages = {1249-1250},
+	Title = {The brain's dark energy},
+	Volume = {314},
+	Year = {2006}}
 
 @article{BindEtal99,
 	Author = {Binder, J R and Frost, J A and Hammeke, T A and Bellgowan, P S F and Rao, S M and Cox, R W},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-08 23:12:06 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-08 23:13:53 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -121,9 +121,16 @@
 	Volume = {333},
 	Year = {2011}}
 
-@article{cite-key,
+@article{ZeitPres10,
+	Author = {Zeithamova, D and Preston, A R},
 	Date-Added = {2019-05-09 03:10:36 +0000},
-	Date-Modified = {2019-05-09 03:10:36 +0000}}
+	Date-Modified = {2019-05-09 03:13:52 +0000},
+	Journal = {Journal of Neuroscience},
+	Number = {44},
+	Pages = {14676-14684},
+	Title = {Flexible memories: differential roles for medial temporal lobe and prefrontal cortex in cross-episode binding},
+	Volume = {30},
+	Year = {2010}}
 
 @article{TseEtal07,
 	Author = {Tse, D and Langston, R F and Kakeyama, M and Bethus, I and Spooner, P A and Wood, E R and Witter, M P and Morris, R G M},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-13 01:34:48 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-13 01:53:10 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{BindEtal99,
+	Author = {Binder, J R and Frost, J A and Hammeke, T A and Bellgowan, P S F and Rao, S M and Cox, R W},
+	Date-Added = {2019-05-13 01:52:12 -0400},
+	Date-Modified = {2019-05-13 01:53:10 -0400},
+	Journal = {Journal of Cognitive Neuroscience},
+	Number = {1},
+	Pages = {80-93},
+	Title = {Conceptual processing during the conscious resting state: a functional MRI study},
+	Volume = {11},
+	Year = {1999}}
 
 @article{CharKoec10,
 	Author = {Charron, S and Koechlin, E},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-13 01:31:51 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-13 01:34:48 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{CharKoec10,
+	Author = {Charron, S and Koechlin, E},
+	Date-Added = {2019-05-13 01:33:46 -0400},
+	Date-Modified = {2019-05-13 01:34:48 -0400},
+	Journal = {Science},
+	Number = {5976},
+	Pages = {360-363},
+	Title = {Divided representations of current goals in the human frontal lobes},
+	Volume = {328},
+	Year = {2010}}
 
 @article{SigmDeha08,
 	Author = {Sigman, M and Dehaene, S},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-08 23:40:15 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-09 01:37:08 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{BargThei85,
+	Author = {Bargh, John A and Thein, R D},
+	Date-Added = {2019-05-09 05:35:38 +0000},
+	Date-Modified = {2019-05-09 05:36:59 +0000},
+	Journal = {Journal of Personality and Social Psychology},
+	Number = {5},
+	Pages = {1129},
+	Title = {Individual construct accessibility, person memory, and the recall-judgment link: The case of information overload},
+	Volume = {49},
+	Year = {1985}}
 
 @article{BarrEtal18,
 	Author = {Barry, D N and Chadwick, M J and Maguire, E A},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-12 16:13:53 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-12 17:39:54 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{KuhlEtal07,
+	Author = {Kuhl, B A and Dudukovic, N M and Kahn, I and Wagner, A D},
+	Date-Added = {2019-05-12 17:39:05 -0400},
+	Date-Modified = {2019-05-12 17:39:54 -0400},
+	Journal = {Nature Neuroscience},
+	Number = {7},
+	Pages = {908},
+	Title = {Decreased demands on cognitive control reveal the neural processing benefits of forgetting},
+	Volume = {10},
+	Year = {2007}}
 
 @article{AndeEtal94,
 	Author = {Anderson, M C and Bjork, R A and Bjork, E L},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-13 01:30:05 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-13 01:31:51 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{SigmDeha08,
+	Author = {Sigman, M and Dehaene, S},
+	Date-Added = {2019-05-13 01:31:03 -0400},
+	Date-Modified = {2019-05-13 01:31:51 -0400},
+	Journal = {Journal of Neuroscience},
+	Number = {30},
+	Pages = {7585-7589},
+	Title = {Brain mechanisms of serial and parallel processing during dual-task performance},
+	Volume = {28},
+	Year = {2008}}
 
 @article{RishEtal13,
 	Author = {Rishel, C A and Huang, G and Freedman, D J},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-13 03:20:18 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-13 03:21:39 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,21 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{HumpEtal07,
+	Author = {Humphries, C and Binder, J R and Medler, D A and Liebenthal, E},
+	Date-Added = {2019-05-13 03:20:57 -0400},
+	Date-Modified = {2019-05-13 03:21:39 -0400},
+	Journal = {Neuroimage},
+	Number = {3},
+	Pages = {924-932},
+	Title = {Time course of semantic processes during sentence comprehension: an fMRI study},
+	Volume = {36},
+	Year = {2007}}
+
+@article{cite-key,
+	Date-Added = {2019-05-13 03:20:44 -0400},
+	Date-Modified = {2019-05-13 03:20:44 -0400}}
 
 @article{XiaoEtal05,
 	Author = {Xiao, Z and Zhang, J X and Wang, X and Wu, R and Hu, X and Weng, X and Tan, L H},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-08 19:41:04 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-08 20:48:42 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -51558,13 +51558,14 @@ Suggest that the findings of increased theta power being associated with INCREAS
 	Volume = {40},
 	Year = {2011}}
 
-@article{RaoHowa07,
+@inproceedings{RaoHowa07,
 	Author = {Rao, V. A. and Howard, M. W.},
+	Booktitle = {Advances in neural information processing systems},
 	Date-Added = {2014-04-04 16:37:02 +0000},
-	Date-Modified = {2014-04-04 16:37:26 +0000},
-	Journal = {Advances in Neural Information Processing Systems},
+	Date-Modified = {2019-05-09 00:48:42 +0000},
+	Pages = {1193-1200},
 	Title = {Retrieved context and the discovery of semantic structure},
-	Year = {in press}}
+	Year = {2008}}
 
 @article{RatcMcKo94,
 	Author = {Ratcliff, R. and Mc{K}oon, G.},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-05-13 17:47:24 -0400 
+%% Created for Paxton Fitzpatrick at 2019-05-13 18:47:14 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{KitaEtal17,
+	Author = {Kitamura, T and Ogawa, S K and Roy, D S and Okuyama, T and Morrissey, M D and Smith, L M and Redondo, R L and Tonegawa, S},
+	Date-Added = {2019-05-13 18:45:58 -0400},
+	Date-Modified = {2019-05-13 18:47:13 -0400},
+	Journal = {Science},
+	Number = {6333},
+	Pages = {73-78},
+	Title = {Engrams and circuits crucial for systems consolidation of a memory},
+	Volume = {356},
+	Year = {2017}}
 
 @article{TambDava13,
 	Author = {Tambini, A and Davachi, L},


### PR DESCRIPTION
### List of citation keys added (one per line)
~85 total added, see commits

### List of citation keys modified (one per line)
- almost all modifications are due to viewing (but not changing) entries not opened since an older version of bibdesk
- updated ZackEtal01 to ZackEtal01a (added ZackEtal01b)
- updated MitcEtal08 to MitcEtal08a (was not updated when MitcEtal08b was added)
- updated RangEtal04 to RangEtal04a (added RangEtal04b)
- updated ChenEtal17 into from preprint to Nature Neuro listing
- updated AlyTurk17 entry type from article to incollection

### Other changes (describe)
removed RaoHowa07 (in-press version of RaoHowa08, which also exists as entry)