### PR TITLE
citations added to sherlock paper revision

### DIFF
--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
-%% https://bibdesk.sourceforge.io/
+%% http://bibdesk.sourceforge.net/
 
-%% Created for Jeremy Manning at 2019-06-25 12:35:59 -0400 
+%% Created for Paxton Fitzpatrick at 2019-07-22 11:42:07 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,17 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{KestEtal13,
+	Author = {van Kesteren, Marlieke T R and Beul, S F and Takashima, A and Henson, R N and Ruiter, D J and Fern{\'{a}}ndez, Guill{\'{e}}n},
+	Date-Added = {2019-07-22 11:36:53 -0400},
+	Date-Modified = {2019-07-22 11:42:07 -0400},
+	Journal = {Neuropsychologia},
+	Number = {12},
+	Pages = {2352-2359},
+	Title = {Differential roles for medial prefrontal and medial temporal cortices in schema-dependent encoding: from congruent to incongruent},
+	Volume = {51},
+	Year = {2013}}
 
 @article{SievEtal13,
 	Author = {B Sievers and L Polansky and M Casey and T Wheatley},
@@ -2561,7 +2572,7 @@
 	Abstract = {Information that is congruent with existing knowledge (a schema) is usually better remembered than less congruent information. Only recently, however, has the role of schemas in memory been studied from a systems neuroscience perspective. Moreover, incongruent (novel) information is also sometimes better remembered. Here, we review lesion and neuroimaging findings in animals and humans that relate to this apparent paradoxical relationship between schema and novelty. In addition, we sketch a framework relating key brain regions in medial temporal lobe (MTL) and medial prefrontal cortex (mPFC) during encoding, consolidation and retrieval of information as a function of its congruency with existing information represented in neocortex. An important aspect of this framework is the efficiency of learning enabled by congruency-dependent MTL-mPFC interactions.},
 	Author = {van Kesteren, Marlieke T R and Ruiter, Dirk J and Fern{\'a}ndez, Guill{\'e}n and Henson, Richard N},
 	Date-Added = {2018-08-28 15:03:31 -0400},
-	Date-Modified = {2018-08-28 15:03:31 -0400},
+	Date-Modified = {2019-07-22 11:37:42 -0400},
 	Doi = {10.1016/j.tins.2012.02.001},
 	Journal = {Trends Neurosci},
 	Journal-Full = {Trends in neurosciences},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2019-07-22 11:42:07 -0400 
+%% Created for Paxton Fitzpatrick at 2019-07-22 14:28:39 -0400 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -109,6 +109,16 @@
 
 @string{vr = {Vision Research}}
 
+
+@article{ByliEtal15,
+	Author = {Bylinskii, Z and Isola, P and Bainbridge, C and Torralba, A and Oliva, A},
+	Date-Added = {2019-07-22 14:27:07 -0400},
+	Date-Modified = {2019-07-22 14:28:39 -0400},
+	Journal = {Vision Research},
+	Pages = {165-178},
+	Title = {Intrinsic and extrinsic effects on image memorability},
+	Volume = {116},
+	Year = {2015}}
 
 @article{KestEtal13,
 	Author = {van Kesteren, Marlieke T R and Beul, S F and Takashima, A and Henson, R N and Ruiter, D J and Fern{\'{a}}ndez, Guill{\'{e}}n},

--- a/memlab.bib
+++ b/memlab.bib
@@ -1,5 +1,5 @@
 %% This BibTeX bibliography file was created using BibDesk.
-%% http://bibdesk.sourceforge.net/
+%% http://bibdesk.sourceforge.io/
 
 %% Created for Paxton Fitzpatrick at 2019-07-22 14:28:39 -0400
 


### PR DESCRIPTION
### List of citation keys added (one per line)
- KestEtal13
- ByliEtal15

### List of citation keys modified (one per line)
- None

### Other changes (describe)
- KestEtal12 appears to be edited but is unchanged. I misread the year for the KestEtal13 paper I added as 2012 and began to change the existing KestEtal12 entry to KestEtal12a, but stopped.
- trailing spaces after lines 2 and 7 appear to have been removed, but do not affect file
