### PR TITLE
added prediction-retrodiction refs

### DIFF
--- a/cdl.bib
+++ b/cdl.bib
@@ -1,3 +1,173 @@
+@article{LangEtal15,
+	Author = {Kristian Lange and Simone Kühn and Elisa Filevich},
+	Journal = {{PLoS} One},
+	Number = {6},
+	Pages = {e0130834},
+	Title = {{"Just Another Tool for Online Studies” (JATOS)}: an easy solution for setup and management of web servers supporting online studies},
+	Volume = {10},
+	Year = {2015}}
+
+@article{DemiEtal18,
+	Author = {Burcu Demiray and Matthias R Mehl and Mike Martin},
+	Journal = {Frontiers in Psychology},
+	Pages = {2160},
+	Title = {Conversational time travel: evidence of a retrospective bias in real life conversations},
+	Volume = {9},
+	Year = {2018}}
+
+@incollection{Cove94,
+	Address = {Cambridge, {UK}},
+	Author = {T M Cover},
+	Booktitle = {Physical Origins of Time Asymmetry},
+	Editor = {Jonathan J Halliwell and Juan P{\'e}rez-Mercader and Wojciech Hubert Zurek},
+	Pages = {98--107},
+	Publisher = {Cambridge {University} Press},
+	Title = {Which processes satisfy the second law?},
+	Year = {1994}}
+
+@inbook{Bord08,
+	Author = {David Bordwell},
+	Chapter = {Three dimensions of film narrative},
+	Pages = {85--134},
+	Publisher = {Routledge London},
+	Title = {Poetics of cinema},
+	Year = {2008}}
+
+@article{Hawk85,
+	Author = {S W Hawking},
+	Journal = {Physical Review {D}},
+	Number = {10},
+	Pages = {2489--2495},
+	Title = {Arrow of time in cosmology},
+	Volume = {32},
+	Year = {1985}}
+
+@article{TamiThor18,
+	Author = {Diana I Tamir and Mark A Thornton},
+	Journal = {Trends in Cognitive Sciences},
+	Number = {3},
+	Pages = {201--212},
+	Title = {Modeling the predictive social mind},
+	Volume = {22},
+	Year = {2018}}
+
+@article{KostSaxe13,
+	Author = {Jorie Koster-Hale and Rebecca Saxe},
+	Journal = {Neuron},
+	Number = {5},
+	Pages = {836--848},
+	Title = {Theory of mind: A neural prediction problem},
+	Volume = {79},
+	Year = {2013}}
+
+@article{EaglSejn00,
+	Author = {David M Eagleman and Terrence J Sejnowski},
+	Journal = {Science},
+	Number = {5460},
+	Pages = {2036--2038},
+	Title = {Motion integration and postdiction in visual awareness},
+	Volume = {287},
+	Year = {2000}}
+
+@article{BialEtal01,
+	Author = {William Bialek and Ilya Nemenman and Naftali Tishby},
+	Journal = {Neural Computation},
+	Number = {11},
+	Pages = {2409--2463},
+	Title = {Predictability, complexity, and learning},
+	Volume = {13},
+	Year = {2001}}
+
+@article{JonePash07,
+	Author = {Jason Jones and Harold Pashler},
+	Journal = {Psychonomic Bulletin and Review},
+	Number = {2},
+	Pages = {295--300},
+	Title = {Is the mind inherently forward looking? Comparing prediction and retrodiction},
+	Volume = {14},
+	Year = {2007}}
+
+@article{PillEtal15,
+	Author = {David B Pillemer and Kristina L Steiner and Kie J Kuwabara and Dorthe Kirkegaard Thomsen and Connie Svob},
+	Journal = {Consciousness and Cognition},
+	Pages = {233--245},
+	Title = {Vicarious memories},
+	Volume = {36},
+	Year = {2015}}
+
+@article{MlodBrun14,
+	Author = {Leonard Mlodinow and Todd A Brun},
+	Journal = {Physical Review {E}},
+	Number = {5},
+	Pages = {052102},
+	Title = {Relation between the psychological and thermodynamic arrows of time},
+	Volume = {89},
+	Year = {2014}}
+
+@article{Dess07,
+	Author = {Jean-Louis Dessalles},
+	Journal = {Behavioral and Brain Sciences},
+	Number = {3},
+	Pages = {321--322},
+	Publisher = {Cambridge {University} Press},
+	Title = {Storing events to retell them},
+	Volume = {30},
+	Year = {2007}}
+
+@article{MahrCsib18,
+	Author = {Johannes B Mahr and Gergely Csibra},
+	Journal = {Behavioral and Brain Sciences},
+	Pages = {e1},
+	Title = {Why do we remember? The communicative function of episodic memory},
+	Volume = {41},
+	Year = {2018}}
+
+@article{HirsEcht12,
+	Author = {William Hirst and Gerald Echterhoff},
+	Journal = {Annual Review of Psychology},
+	Number = {1},
+	Pages = {55--79},
+	Title = {Remembering in conversations: the social sharing and reshaping of memories},
+	Volume = {63},
+	Year = {2012}}
+
+@article{HassEtal20,
+	Author = {Uri Hasson and Samuel A Nastase and Ariel Goldstein},
+	Journal = {Neuron},
+	Number = {3},
+	Pages = {416--434},
+	Title = {Direct fit to nature: an evolutionary perspective on biological and artificial neural networks},
+	Volume = {105},
+	Year = {2020}}
+
+@article{ChanEtal20,
+	Author = {Claire H C Chang and Christina Lazaridi and Yaara Yeshurun and Kenneth A Norman and Uri Hasson},
+	Journal = {{bioRxiv}},
+	Pages = {2020.01.16.908731},
+	Title = {Relating the past with the present: information integration and segregation during ongoing narrative processing},
+	Year = {2020}}
+
+@article{CohnEtal20,
+	Author = {Brendan Cohn-Sheehy and Angelique Delarazan and Zachariah Reagh and Nidhi Mundada and Andrew Yonelinas and Jeffrey M Zacks and Charan Ranganath},
+	Publisher = {{PsyArXiv}},
+	Title = {Narratives bridge the divide between distant events in episodic memory},
+	Year = {2020}}
+
+@article{ThorTami20,
+	Author = {Mark A Thornton and Diana I Tamir},
+	Journal = {Social Cognitive and Affective Neuroscience},
+	Title = {Perceiving actions before they happen:psychological dimensions scaffold neural action prediction},
+	Year = {2020}}
+
+@article{RichSaxe20,
+	Author = {Hilary Richardson and Rebecca Saxe},
+	Journal = {Developmental Science},
+	Number = {1},
+	Pages = {e12863},
+	Title = {Development of predictive responses in theory of mind brain regions},
+	Volume = {23},
+	Year = {2020}}
+
 @article{WangEtal20,
 	Author = {C Wang and J Huang and D C Brien and D P Munoz},
 	Journal = {Biological Psychology},


### PR DESCRIPTION
### List of citation keys added (one per line)
Hawk85, 
Dess07, 
HassEtal20, 
PillEtal15,
RichSaxe20, 
MlodBrun14, 
BialEtal01, 
MahrCsib18, 
KostSaxe13, 
JonePash07, 
LangEtal15, 
DemiEtal18, 
Bord08, 
ThorTami20, 
Cove94, 
TamiThor18, 
ChanEtal20, 
CohnEtal20, 
EaglSejn00, 
HirsEcht12

### List of citation keys modified (one per line)

### Other changes (describe)
