### PR TITLE
fixes for bibchecker/CI tests

### DIFF
--- a/.github/workflows/autocheck.yml
+++ b/.github/workflows/autocheck.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.9
       - name: install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *__pycache*
 cdl.bib.bak
 cdl.bib.sav.tmp
+.idea/

--- a/bibcheck/caps.txt
+++ b/bibcheck/caps.txt
@@ -385,3 +385,4 @@ EMBS
 BHI
 Third
 RDoC
+USENIX

--- a/cdl.bib
+++ b/cdl.bib
@@ -1,12 +1,23 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2021-11-08 12:10:33 -0500 
+%% Created for Paxton Fitzpatrick at 2021-11-08 12:29:58 -0500 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
 
 
+
+@article{HarrEtal20,
+	author = {Charles R. Harris and K. Jarrod Millman and St{\'{e}}fan J. van der Walt and Ralf Gommers and Pauli Virtanen and David Cournapeau and Eric Wieser and Julian Taylor and Sebastian Berg and Nathaniel J. Smith and Robert Kern and Matti Picus and Stephan Hoyer and Marten H. van Kerkwijk and Matthew Brett and Allan Haldane and Jaime Fern{\'{a}}ndez del R{\'{i}}o and Mark Wiebe and Pearu Peterson and Pierre G{\'{e}}rard-Marchant and Kevin Sheppard and Tyler Reddy and Warren Weckesser and Hameer Abbasi and Christoph Gohlke and Travis E. Oliphant},
+	date-added = {2021-11-08 12:27:11 -0500},
+	date-modified = {2021-11-08 12:29:29 -0500},
+	journal = {Nature},
+	number = {7825},
+	pages = {357--362},
+	title = {Array programming with {NumPy}},
+	volume = {585},
+	year = {2020}}
 
 @inproceedings{KluyEtal16,
 	address = {Netherlands},

--- a/cdl.bib
+++ b/cdl.bib
@@ -1,12 +1,22 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2021-11-14 16:04:45 -0500
+%% Created for Paxton Fitzpatrick at 2021-12-04 14:49:28 -0500 
 
 
-%% Saved with string encoding Unicode (UTF-8)
+%% Saved with string encoding Unicode (UTF-8) 
 
 
+
+@article{MullEtal15,
+	author = {Muller, Eilif and Bednar, James A and Diesmann, Markus and Gewaltig, Marc-Oliver and Hines, Michael and Davison, Andrew P},
+	date-added = {2021-12-04 14:48:00 -0500},
+	date-modified = {2021-12-04 14:49:22 -0500},
+	journal = {Frontiers in Neuroinformatics},
+	pages = {11},
+	title = {Python in neuroscience},
+	volume = {9},
+	year = {2015}}
 
 @techreport{vanREtal14,
 	author = {Guido {van Rossum} and Jukka Lehtosalo and {\L}ukasz Langa},
@@ -16,8 +26,9 @@
 	number = {484},
 	title = {Type {Hints}},
 	type = {PEP},
+	url = {https://www.python.org/dev/peps/pep-0484},
 	year = {2014},
-	url = {https://www.python.org/dev/peps/pep-0484}}
+	bdsk-url-1 = {https://www.python.org/dev/peps/pep-0484}}
 
 @article{Wask21,
 	author = {Michael L. Waskom},

--- a/cdl.bib
+++ b/cdl.bib
@@ -1,8 +1,6 @@
 
 @article{ChiaEtal22,
 	author = {F-K Chiang and J D Wallis and E L Rich},
-	date-added = {2022-03-26 14:19:22 -0400},
-	date-modified = {2022-03-26 14:20:10 -0400},
 	journal = {Neuron},
 	number = {4},
 	pages = {709--721},

--- a/cdl.bib
+++ b/cdl.bib
@@ -1,7 +1,7 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2021-12-14 14:51:09 -0500 
+%% Created for Paxton Fitzpatrick at 2021-12-20 00:42:54 -0500 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
@@ -43,8 +43,8 @@
 @article{Wask21,
 	author = {Michael L. Waskom},
 	date-added = {2021-11-08 12:43:32 -0500},
-	date-modified = {2021-11-08 12:44:48 -0500},
-	journal = {The Open Journal},
+	date-modified = {2021-12-20 00:42:54 -0500},
+	journal = {Journal of Open Source Software},
 	number = {60},
 	pages = {3021},
 	title = {seaborn: statistical data visualization},

--- a/cdl.bib
+++ b/cdl.bib
@@ -1,12 +1,22 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2021-12-04 14:49:28 -0500 
+%% Created for Paxton Fitzpatrick at 2021-12-14 14:51:09 -0500 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
 
 
+
+@inproceedings{RagaWill18,
+	author = {Ragan-Kelley, Benjamin and Willing, Carol},
+	booktitle = {Proceedings of the 17th Python in Science Conference},
+	date-added = {2021-12-14 14:48:23 -0500},
+	date-modified = {2021-12-14 14:51:08 -0500},
+	editor = {Akici, F and Lippa, D and Niederhut, D and and Pacer, M},
+	pages = {113--120},
+	title = {Binder 2.0-Reproducible, interactive, sharable environments for science at scale},
+	year = {2018}}
 
 @article{MullEtal15,
 	author = {Muller, Eilif and Bednar, James A and Diesmann, Markus and Gewaltig, Marc-Oliver and Hines, Michael and Davison, Andrew P},

--- a/cdl.bib
+++ b/cdl.bib
@@ -1,3 +1,24 @@
+%% This BibTeX bibliography file was created using BibDesk.
+%% http://bibdesk.sourceforge.net/
+
+%% Created for Paxton Fitzpatrick at 2021-11-08 12:00:20 -0500 
+
+
+%% Saved with string encoding Unicode (UTF-8) 
+
+
+
+@article{PereGran07,
+	author = {F P{\'e}rez and B E Granger},
+	date-added = {2021-11-08 11:51:10 -0500},
+	date-modified = {2021-11-08 11:54:56 -0500},
+	journal = {Computing in science \& engineering},
+	number = {3},
+	pages = {21--29},
+	title = {IPython: a system for interactive scientific computing},
+	volume = {9},
+	year = {2007}}
+
 @article{FinnBand21,
 	author = {E S Finn and P A Bandettini},
 	journal = {{NeuroImage}},
@@ -315,10 +336,10 @@
 
 @techreport{CartEtal16,
 	author = {C Carter and N Cohen and J {DeVylder} and D Dickinson and D Fair and M Kutas and S Park and L Uddin},
+	force = {True},
 	institution = {National Institutes of Mental Health},
 	title = {Behavioral assessment methods for {RDoC} constructs: cognitive systems final report},
-	year = {2016},
-	force = {True}}
+	year = {2016}}
 
 @article{MannEtal21,
 	author = {J R Manning and G M Notaro and E Chen and P C Fitzpatrick},

--- a/cdl.bib
+++ b/cdl.bib
@@ -1,12 +1,23 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2021-11-08 12:34:27 -0500 
+%% Created for Paxton Fitzpatrick at 2021-11-08 12:49:30 -0500 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
 
 
+
+@article{Wask21,
+	author = {Michael L. Waskom},
+	date-added = {2021-11-08 12:43:32 -0500},
+	date-modified = {2021-11-08 12:44:48 -0500},
+	journal = {The Open Journal},
+	number = {60},
+	pages = {3021},
+	title = {seaborn: statistical data visualization},
+	volume = {6},
+	year = {2021}}
 
 @article{VirtEtal20,
 	author = {Virtanen, Pauli and Gommers, Ralf and Oliphant, Travis E. and Haberland, Matt and Reddy, Tyler and Cournapeau, David and Burovski, Evgeni and Peterson, Pearu and Weckesser, Warren and Bright, Jonathan and {van der Walt}, St{\'e}fan J. and Brett, Matthew and Wilson, Joshua and Millman, K. Jarrod and Mayorov, Nikolay and Nelson, Andrew R. J. and Jones, Eric and Kern, Robert and Larson, Eric and Carey, C J and Polat, {\.I}lhan and Feng, Yu and Moore, Eric W. and {VanderPlas}, Jake and Laxalde, Denis and Perktold, Josef and Cimrman, Robert and Henriksen, Ian and Quintero, E. A. and Harris, Charles R. and Archibald, Anne M. and Ribeiro, Ant{\^o}nio H. and Pedregosa, Fabian and {van Mulbregt}, Paul and {SciPy 1.0 Contributors}},

--- a/cdl.bib
+++ b/cdl.bib
@@ -1,12 +1,23 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2021-11-08 12:49:30 -0500 
+%% Created for Paxton Fitzpatrick at 2021-11-14 16:04:45 -0500
 
 
-%% Saved with string encoding Unicode (UTF-8) 
+%% Saved with string encoding Unicode (UTF-8)
 
 
+
+@techreport{vanREtal14,
+	author = {Guido {van Rossum} and Jukka Lehtosalo and {\L}ukasz Langa},
+	date-added = {2021-11-14 15:32:37 -0500},
+	date-modified = {2021-11-14 16:03:18 -0500},
+	month = {September},
+	number = {484},
+	title = {Type {Hints}},
+	type = {PEP},
+	year = {2014},
+	url = {https://www.python.org/dev/peps/pep-0484}}
 
 @article{Wask21,
 	author = {Michael L. Waskom},

--- a/cdl.bib
+++ b/cdl.bib
@@ -1,12 +1,23 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2021-11-08 12:29:58 -0500 
+%% Created for Paxton Fitzpatrick at 2021-11-08 12:34:27 -0500 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
 
 
+
+@article{VirtEtal20,
+	author = {Virtanen, Pauli and Gommers, Ralf and Oliphant, Travis E. and Haberland, Matt and Reddy, Tyler and Cournapeau, David and Burovski, Evgeni and Peterson, Pearu and Weckesser, Warren and Bright, Jonathan and {van der Walt}, St{\'e}fan J. and Brett, Matthew and Wilson, Joshua and Millman, K. Jarrod and Mayorov, Nikolay and Nelson, Andrew R. J. and Jones, Eric and Kern, Robert and Larson, Eric and Carey, C J and Polat, {\.I}lhan and Feng, Yu and Moore, Eric W. and {VanderPlas}, Jake and Laxalde, Denis and Perktold, Josef and Cimrman, Robert and Henriksen, Ian and Quintero, E. A. and Harris, Charles R. and Archibald, Anne M. and Ribeiro, Ant{\^o}nio H. and Pedregosa, Fabian and {van Mulbregt}, Paul and {SciPy 1.0 Contributors}},
+	date-added = {2021-11-08 12:33:00 -0500},
+	date-modified = {2021-11-08 12:34:27 -0500},
+	journal = {Nature Methods},
+	number = {3},
+	pages = {261--272},
+	title = {{{SciPy} 1.0: Fundamental Algorithms for Scientific Computing in Python}},
+	volume = {17},
+	year = {2020}}
 
 @article{HarrEtal20,
 	author = {Charles R. Harris and K. Jarrod Millman and St{\'{e}}fan J. van der Walt and Ralf Gommers and Pauli Virtanen and David Cournapeau and Eric Wieser and Julian Taylor and Sebastian Berg and Nathaniel J. Smith and Robert Kern and Matti Picus and Stephan Hoyer and Marten H. van Kerkwijk and Matthew Brett and Allan Haldane and Jaime Fern{\'{a}}ndez del R{\'{i}}o and Mark Wiebe and Pearu Peterson and Pierre G{\'{e}}rard-Marchant and Kevin Sheppard and Tyler Reddy and Warren Weckesser and Hameer Abbasi and Christoph Gohlke and Travis E. Oliphant},

--- a/cdl.bib
+++ b/cdl.bib
@@ -1,12 +1,24 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% http://bibdesk.sourceforge.net/
 
-%% Created for Paxton Fitzpatrick at 2021-11-08 12:00:20 -0500 
+%% Created for Paxton Fitzpatrick at 2021-11-08 12:10:33 -0500 
 
 
 %% Saved with string encoding Unicode (UTF-8) 
 
 
+
+@inproceedings{KluyEtal16,
+	address = {Netherlands},
+	author = {Thomas Kluyver and Benjamin Ragan-Kelley and Fernando P{\'e}rez and Brian Granger and Matthias Bussonnier and Jonathan Frederic and Kyle Kelley and Jessica Hamrick and Jason Grout and Sylvain Corlay and Paul Ivanov and Dami{\'a}n Avila and Safia Abdalla and Carol Willing},
+	booktitle = {Positioning and Power in Academic Publishing: Players, Agents and Agendas},
+	date-added = {2021-11-08 12:02:43 -0500},
+	date-modified = {2021-11-08 12:10:32 -0500},
+	editor = {Fernando Loizides and Birgit Scmidt},
+	pages = {97--90},
+	publisher = {IOS Press},
+	title = {Jupyter Notebooks -- a publishing format for reproducible computational workflows.},
+	year = {2016}}
 
 @article{PereGran07,
 	author = {F P{\'e}rez and B E Granger},

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 unidecode==1.1.1
 bibtexparser==1.2.0
-numpy==1.22.0
+numpy==1.23.0
 pandas==1.1.5
 xlrd==2.0.1
 typer==0.3.2


### PR DESCRIPTION
### List of citation keys added (one per line)
None -- commits whose messages reference adding keys were overwritten (intentionally) in [115c342](https://github.com/ContextLab/CDL-bibliography/commit/115c342c06a0de4b0ed4d55f9a86afda54e4a1f1). These added-and-removed references were all `davos`-related and will ultimately be added back in anyway in a future PR, but I want to merge this for now so the version of ContextLab/CDL-bibliography I add to the `davos` repo as a submodule is clean, working properly, and even with paxtonfitzpatrick/CDL-bibliography (where I'll be pushing changes for that future PR).

### List of citation keys modified (one per line)
- ChiaEtal22 -- removed extraneous date-added and date-modified fields per the bibchecker

### Other changes (describe)
- add JetBrains project config dir (`.idea/`) to .gitignore
- bump Python version used in CI tests from 3.7 to 3.9 

  `numpy` upgrade via dependabot (#56) requires Python v3.8+, causing CI tests to fail. Went ahead and additionally bumped Python to 3.9 instead of 3.8 for consistency with the min. version needed to run the bibchecker locally on ARM Macs

- bump `numpy` version from v1.22.0 to 1.23.0

  pinned `pandas` version (v1.1.5) had an odd compatibility bug with `numpy` v1.22.0, so I upgraded the `numpy` version to fix it.

- add "USENIX" to caps.txt 

  "Journal" field for AbadEtal16 (TensorFlow reference) is "`Proceedings of the {USENIX} Symposium on Operating Systems Design and Implementation`". bibcheck was flagging it and requesting `{usenix}` instead, which it shouldn't.

CI tests are still failing for one last rather interesting reason I'll describe in a comment below