### PR TITLE
additional citations for davos paper

### DIFF
--- a/cdl.bib
+++ b/cdl.bib
@@ -5,8 +5,6 @@
 
 @techreport{Shan20,
 	author = {M Shannon},
-	date-added = {2022-11-16 18:16:26 -0500},
-	date-modified = {2022-11-16 18:19:46 -0500},
 	institution = {Python Software Foundation},
 	month = {September},
 	number = {638},
@@ -14,20 +12,18 @@
 	type = {Draft PEP},
 	year = {2020}}
 
-@misc{CaspEtal22,
-	author = {Casper da Costa-Luis and Stephen Karl Larroque and Kyle Altendorf and Hadrien Mary and richardsheridan and Mikhail Korobov and Noam Raphael and Ivan Ivanov and Marcel Bargull and Nishant Rodrigues and Guangshuo Chen and Antony Lee and Charles Newey and CrazyPython and JC and Martin Zugnoni and Matthew D. Pagel and mjstevens777 and Mikhail Dektyarev and Alex Rothberg and Alexander Plavin and Daniel Panteleit and Fabian Dill and FichteFoll and Gregor Sturm and HeoHeo and Hugo van Kemenade and Jack McCracken and MapleCCC and Max Nordlund},
-	date-added = {2022-11-14 16:30:02 -0500},
-	date-modified = {2022-11-14 16:32:24 -0500},
+@misc{daCoEtal22,
+	author = {Casper da Costa-Luis and Stephen Karl Larroque and Kyle Altendorf and Hadrien Mary and richardsheridan and Mikhail Korobov and Noam Raphael and Ivan Ivanov and Marcel Bargull and Nishant Rodrigues and Guangshuo Chen and Antony Lee and Charles Newey and CrazyPython and {JC} and Martin Zugnoni and Matthew D. Pagel and mjstevens777 and Mikhail Dektyarev and Alex Rothberg and Alexander Plavin and Daniel Panteleit and Fabian Dill and FichteFoll and Gregor Sturm and HeoHeo and Hugo van Kemenade and Jack McCracken and MapleCCC and Max Nordlund},
 	doi = {10.5281/zenodo.595120},
+    force = {True},
 	howpublished = {\url{https://github.com/tqdm/tqdm}},
 	month = {September},
 	title = {{tqdm}: A {F}ast, {E}xtensible {P}rogress {B}ar for {P}ython and {CLI}},
 	year = {2022}}
 
-@misc{GrouEtal15,
+@misc{FredEtal15,
 	author = {J Frederic and J Grout and {Jupyter Widgets Contributors}},
-	date-added = {2022-11-11 22:40:10 -0500},
-	date-modified = {2022-11-11 22:54:30 -0500},
+    force = {True},
 	howpublished = {\url{https://github.com/jupyter-widgets/ipywidgets}},
 	month = {August},
 	title = {{ipywidgets: Interactive Widgets for the Jupyter Notebook}},
@@ -35,8 +31,6 @@
 
 @article{McInEtal18b,
 	author = {L McInnes and J Healy and N Saul and L Gro{\ss}berger},
-	date-added = {2022-11-03 20:56:47 -0400},
-	date-modified = {2022-11-03 21:03:58 -0400},
 	doi = {https://doi.org/10.21105/joss.00861},
 	journal = {Journal of Open Source Software},
 	number = {29},
@@ -47,8 +41,6 @@
 
 @misc{Varo10,
 	author = {Ga\"{e}l Varoquaux},
-	date-added = {2022-11-01 17:50:15 -0400},
-	date-modified = {2022-11-01 17:57:52 -0400},
 	howpublished = {\url{https://github.com/joblib/joblib}},
 	month = {July},
 	title = {Joblib: {C}omputing with {P}ython functions},
@@ -56,8 +48,6 @@
 
 @misc{Eust19,
 	author = {S{\'{e}}bastien Eustace},
-	date-added = {2022-10-26 13:46:44 -0400},
-	date-modified = {2022-10-26 13:51:02 -0400},
 	howpublished = {\url{https://github.com/python-poetry/poetry}},
 	month = {December},
 	title = {Poetry: {Python} packaging and dependency management made easy},
@@ -65,19 +55,15 @@
 
 @techreport{CannEtal16,
 	author = {Brett Cannon and Nathaniel Smith and Donald Stufft},
-	date-added = {2022-10-26 13:25:25 -0400},
-	date-modified = {2022-10-26 13:27:03 -0400},
 	institution = {Python Software Foundation},
 	month = {May},
 	number = {518},
-	title = {Specifying Minimum Build System Requirements for Python Projects},
+	title = {Specifying {M}inimum {B}uild {S}ystem {R}equirements for {Python} {P}rojects},
 	type = {PEP},
 	year = {2016}}
 
 @misc{Gaut08,
 	author = {L Gautier},
-	date-added = {2022-10-25 20:14:49 -0400},
-	date-modified = {2022-10-25 20:18:10 -0400},
 	howpublished = {\url{https://github.com/rpy2/rpy2}},
 	month = {November},
 	title = {{rpy2}: A {S}imple and {E}fficient {A}ccess to {R} from {P}ython},
@@ -231,7 +217,6 @@
 
 @misc{Mann21e,
 	author = {J R Manning},
-	date-modified = {2022-11-01 17:59:32 -0400},
 	doi = {10.5281/zenodo.7261831},
 	force = {True},
 	howpublished = {\url{https://github.com/ContextLab/abstract2paper}},
@@ -5128,7 +5113,6 @@
 
 @article{McInEtal18a,
 	author = {L McInnes and J Healy and J Melville},
-	date-modified = {2022-11-03 20:56:43 -0400},
 	journal = {{arXiv}},
 	month = {February},
 	number = {03426},
@@ -7122,8 +7106,7 @@
 
 @inproceedings{McKi10,
 	author = {Wes McKinney},
-	booktitle = {Proceedings of the 9th Python in Science Conference},
-	date-modified = {2022-11-01 13:56:50 -0400},
+	booktitle = {Proceedings of the 9th {Python} in Science Conference},
 	doi = {10.25080/Majora-92bf1922-00a},
 	editor = {St\'efan van der Walt and Jarrod Millman},
 	pages = {56--61},

--- a/cdl.bib
+++ b/cdl.bib
@@ -3,6 +3,25 @@
 
 
 
+@misc{CaspEtal22,
+	author = {Casper da Costa-Luis and Stephen Karl Larroque and Kyle Altendorf and Hadrien Mary and richardsheridan and Mikhail Korobov and Noam Raphael and Ivan Ivanov and Marcel Bargull and Nishant Rodrigues and Guangshuo Chen and Antony Lee and Charles Newey and CrazyPython and JC and Martin Zugnoni and Matthew D. Pagel and mjstevens777 and Mikhail Dektyarev and Alex Rothberg and Alexander Plavin and Daniel Panteleit and Fabian Dill and FichteFoll and Gregor Sturm and HeoHeo and Hugo van Kemenade and Jack McCracken and MapleCCC and Max Nordlund},
+	date-added = {2022-11-14 16:30:02 -0500},
+	date-modified = {2022-11-14 16:32:24 -0500},
+	doi = {10.5281/zenodo.595120},
+	howpublished = {\url{https://github.com/tqdm/tqdm}},
+	month = {September},
+	title = {{tqdm}: A {F}ast, {E}xtensible {P}rogress {B}ar for {P}ython and {CLI}},
+	year = {2022}}
+
+@misc{GrouEtal15,
+	author = {J Frederic and J Grout and {Jupyter Widgets Contributors}},
+	date-added = {2022-11-11 22:40:10 -0500},
+	date-modified = {2022-11-11 22:54:30 -0500},
+	howpublished = {\url{https://github.com/jupyter-widgets/ipywidgets}},
+	month = {August},
+	title = {{ipywidgets: Interactive Widgets for the Jupyter Notebook}},
+	year = {2015}}
+
 @article{McInEtal18b,
 	author = {L McInnes and J Healy and N Saul and L Gro{\ss}berger},
 	date-added = {2022-11-03 20:56:47 -0400},

--- a/cdl.bib
+++ b/cdl.bib
@@ -3,6 +3,17 @@
 
 
 
+@techreport{Shan20,
+	author = {M Shannon},
+	date-added = {2022-11-16 18:16:26 -0500},
+	date-modified = {2022-11-16 18:19:46 -0500},
+	institution = {Python Software Foundation},
+	month = {September},
+	number = {638},
+	title = {Syntactic {M}acros},
+	type = {Draft PEP},
+	year = {2020}}
+
 @misc{CaspEtal22,
 	author = {Casper da Costa-Luis and Stephen Karl Larroque and Kyle Altendorf and Hadrien Mary and richardsheridan and Mikhail Korobov and Noam Raphael and Ivan Ivanov and Marcel Bargull and Nishant Rodrigues and Guangshuo Chen and Antony Lee and Charles Newey and CrazyPython and JC and Martin Zugnoni and Matthew D. Pagel and mjstevens777 and Mikhail Dektyarev and Alex Rothberg and Alexander Plavin and Daniel Panteleit and Fabian Dill and FichteFoll and Gregor Sturm and HeoHeo and Hugo van Kemenade and Jack McCracken and MapleCCC and Max Nordlund},
 	date-added = {2022-11-14 16:30:02 -0500},

--- a/cdl.bib
+++ b/cdl.bib
@@ -3,6 +3,17 @@
 
 
 
+@techreport{CannEtal16,
+	author = {Brett Cannon and Nathaniel Smith and Donald Stufft},
+	date-added = {2022-10-26 13:25:25 -0400},
+	date-modified = {2022-10-26 13:27:03 -0400},
+	institution = {Python Software Foundation},
+	month = {May},
+	number = {518},
+	title = {Specifying Minimum Build System Requirements for Python Projects},
+	type = {PEP},
+	year = {2016}}
+
 @misc{Gaut08,
 	author = {L Gautier},
 	date-added = {2022-10-25 20:14:49 -0400},

--- a/cdl.bib
+++ b/cdl.bib
@@ -3,6 +3,15 @@
 
 
 
+@misc{Eust19,
+	author = {S{\'{e}}bastien Eustace},
+	date-added = {2022-10-26 13:46:44 -0400},
+	date-modified = {2022-10-26 13:51:02 -0400},
+	howpublished = {\url{https://github.com/python-poetry/poetry}},
+	month = {December},
+	title = {Poetry: {Python} packaging and dependency management made easy},
+	year = {2019}}
+
 @techreport{CannEtal16,
 	author = {Brett Cannon and Nathaniel Smith and Donald Stufft},
 	date-added = {2022-10-26 13:25:25 -0400},

--- a/cdl.bib
+++ b/cdl.bib
@@ -3,6 +3,15 @@
 
 
 
+@misc{Gaut08,
+	author = {L Gautier},
+	date-added = {2022-10-25 20:14:49 -0400},
+	date-modified = {2022-10-25 20:18:10 -0400},
+	howpublished = {\url{https://github.com/rpy2/rpy2}},
+	month = {November},
+	title = {{rpy2}: A {S}imple and {E}fficient {A}ccess to {R} from {P}ython},
+	year = {2008}}
+
 @misc{Mann22,
     author = {Jeremy Manning},
     doi = {10.5281/zenodo.6596762},

--- a/cdl.bib
+++ b/cdl.bib
@@ -7066,11 +7066,13 @@
 	year = {2012}}
 
 @inproceedings{McKi10,
-	author = {W McKinney},
-	booktitle = {Proceedings of the {Python} in Science Conference},
+	author = {Wes McKinney},
+	booktitle = {Proceedings of the 9th Python in Science Conference},
+	date-modified = {2022-11-01 13:56:50 -0400},
 	doi = {10.25080/Majora-92bf1922-00a},
-	pages = {51--56},
-	title = {Data structures for statistical computing in {P}ython},
+	editor = {St\'efan van der Walt and Jarrod Millman},
+	pages = {56--61},
+	title = {Data {S}tructures for {S}tatistical {C}omputing in {P}ython},
 	year = {2010}}
 
 @article{PedrEtal11,

--- a/cdl.bib
+++ b/cdl.bib
@@ -3,6 +3,15 @@
 
 
 
+@misc{Varo10,
+	author = {Ga\"{e}l Varoquaux},
+	date-added = {2022-11-01 17:50:15 -0400},
+	date-modified = {2022-11-01 17:57:52 -0400},
+	howpublished = {\url{https://github.com/joblib/joblib}},
+	month = {July},
+	title = {Joblib: {C}omputing with {P}ython functions},
+	year = {2010}}
+
 @misc{Eust19,
 	author = {S{\'{e}}bastien Eustace},
 	date-added = {2022-10-26 13:46:44 -0400},

--- a/cdl.bib
+++ b/cdl.bib
@@ -3,6 +3,18 @@
 
 
 
+@article{McInEtal18b,
+	author = {L McInnes and J Healy and N Saul and L Gro{\ss}berger},
+	date-added = {2022-11-03 20:56:47 -0400},
+	date-modified = {2022-11-03 21:03:58 -0400},
+	doi = {https://doi.org/10.21105/joss.00861},
+	journal = {Journal of Open Source Software},
+	number = {29},
+	pages = {861},
+	title = {{UMAP}: {U}niform {M}anifold {A}pproximation and {P}rojection},
+	volume = {3},
+	year = {2018}}
+
 @misc{Varo10,
 	author = {Ga\"{e}l Varoquaux},
 	date-added = {2022-11-01 17:50:15 -0400},
@@ -5084,11 +5096,13 @@
 	volume = {35},
 	year = {2012}}
 
-@article{McInEtal18,
+@article{McInEtal18a,
 	author = {L McInnes and J Healy and J Melville},
+	date-modified = {2022-11-03 20:56:43 -0400},
 	journal = {{arXiv}},
+	month = {February},
 	number = {03426},
-	title = {{UMAP}: uniform manifold approximation and projection for dimension reduction},
+	title = {{UMAP}: {U}niform {m}anifold {a}pproximation and {p}rojection for {d}imension {r}eduction},
 	volume = {1802},
 	year = {2018}}
 

--- a/cdl.bib
+++ b/cdl.bib
@@ -24,29 +24,29 @@
 	year = {2008}}
 
 @misc{Mann22,
-    author = {Jeremy Manning},
-    doi = {10.5281/zenodo.6596762},
-    force = {True},
-    howpublished = {\url{https://github.com/ContextLab/experimental-psychology/tree/v1.0}},
-    month = {May},
-    publisher = {Zenodo},
-    title = {{ContextLab/experimental-psychology: v1.0 (Spring, 2022)}},
-    year = {2022}}
+	author = {Jeremy Manning},
+	doi = {10.5281/zenodo.6596762},
+	force = {True},
+	howpublished = {\url{https://github.com/ContextLab/experimental-psychology/tree/v1.0}},
+	month = {May},
+	publisher = {Zenodo},
+	title = {{ContextLab/experimental-psychology: v1.0 (Spring, 2022)}},
+	year = {2022}}
 
 @article{GaoEtal20,
 	author = {Gao, Leo and Biderman, Stella and Black, Sid and Golding, Laurence and Hoppe, Travis and Foster, Charles and Phang, Jason and He, Horace and Thite, Anish and Nabeshima, Noa and Presser, Shawn and Leahy, Connor},
-    force = {True},
+	force = {True},
 	journal = {{arXiv} preprint ar{X}iv:2101.00027},
 	title = {{The Pile: An 800GB Dataset of Diverse Text for Language Modeling}},
 	year = {2020}}
 
 @misc{BlacEtal21,
-    author = {Black, Sid and Gao, Leo and Wang, Phil and Leahy, Connor and Biderman, Stella},
-    force = {True},
-    howpublished = {\url{http://github.com/eleutherai/gpt-neo}},
-    title = {{GPT-Neo: Large Scale Autoregressive Language Modeling with Mesh-Tensorflow}},
-    version = {1.0},
-    year = {2021}}
+	author = {Black, Sid and Gao, Leo and Wang, Phil and Leahy, Connor and Biderman, Stella},
+	force = {True},
+	howpublished = {\url{http://github.com/eleutherai/gpt-neo}},
+	title = {{GPT-Neo: Large Scale Autoregressive Language Modeling with Mesh-Tensorflow}},
+	version = {1.0},
+	year = {2021}}
 
 @article{Thom68,
 	author = {Ken Thompson},
@@ -62,7 +62,6 @@
 
 @misc{cond15,
 	author = {conda-forge community},
-    force = {True},
 	doi = {10.5281/zenodo.4774217},
 	force = {True},
 	howpublished = {\url{https://doi.org/10.5281/zenodo.4774217}},
@@ -82,14 +81,14 @@
 
 @misc{Anac12,
 	author = {{Anaconda, Inc.}},
-    force = {True},
+	force = {True},
 	howpublished = {\url{https://docs.conda.io}},
 	title = {{conda}},
 	year = {2012}}
 
 @misc{Pyth03,
 	author = {{Python Software Foundation}},
-    force = {True},
+	force = {True},
 	howpublished = {\url{https://pypi.org}},
 	publisher = {Python Software Foundation},
 	title = {The {P}ython {P}ackage {I}ndex ({PyPI})},
@@ -97,8 +96,8 @@
 
 @inproceedings{Rose99,
 	author = {Mendel Rosenblum},
-    force = {True},
 	booktitle = {{IEEE} Hot Chips Symposium},
+	force = {True},
 	pages = {185--196},
 	publisher = {{IEEE}},
 	title = {{VMware's Virtual Platform: A virtual machine monitor for commodity PCs}},
@@ -134,7 +133,7 @@
 
 @article{GranGrou16,
 	author = {B Granger and J Grout},
-    force = {True},
+	force = {True},
 	journal = {Slides of presentation made at {SciPy}},
 	title = {Jupyter{L}ab: {B}uilding blocks for interactive computing},
 	year = {2016}}
@@ -172,16 +171,16 @@
 
 @misc{Mann21e,
 	author = {J R Manning},
-    force = {True},
-    howpublished = {\url{https://github.com/ContextLab/abstract2paper}},
-    month = {June},
+	force = {True},
+	howpublished = {\url{https://github.com/ContextLab/abstract2paper}},
+	month = {June},
 	title = {{abstract2paper}},
 	year = {2021}}
 
 @misc{Mann21d,
 	author = {J R Manning},
 	doi = {10.5281/zenodo.5182775},
-    howpublished = {\url{https://github.com/ContextLab/storytelling-with-data}},
+	howpublished = {\url{https://github.com/ContextLab/storytelling-with-data}},
 	month = {June},
 	publisher = {Zenodo},
 	title = {Storytelling with {D}ata},
@@ -227,7 +226,7 @@
 
 @article{vanR95,
 	author = {Guido {van Rossum}},
-    force = {True},
+	force = {True},
 	journal = {Department of Computer Science {[CS]}},
 	number = {R 9525},
 	publisher = {{CWI}},

--- a/cdl.bib
+++ b/cdl.bib
@@ -189,6 +189,8 @@
 
 @misc{Mann21e,
 	author = {J R Manning},
+	date-modified = {2022-11-01 17:59:32 -0400},
+	doi = {10.5281/zenodo.7261831},
 	force = {True},
 	howpublished = {\url{https://github.com/ContextLab/abstract2paper}},
 	month = {June},


### PR DESCRIPTION
### List of citation keys added (one per line)
- Gaut08
- CannEtal16
- Eust19
- Varo10
- McInEtal18b
- CaspEtal22
- Shan20

### List of citation keys modified (one per line)
- McKi10 (add missing fields)
- Mann21e (add DOI)
- McInEtal18 (➡️ McInEtal18a)

### Other changes (describe)
minor fixes to pass bibcheck