### PR TITLE
final updates for davos paper

### DIFF
--- a/bibcheck/keep_fields.txt
+++ b/bibcheck/keep_fields.txt
@@ -20,3 +20,4 @@ institution
 month
 type
 howpublished
+series

--- a/cdl.bib
+++ b/cdl.bib
@@ -3,14 +3,13 @@
 
 
 
-@book{Mart12,
-	address = {London, England},
+@book{Mart98,
 	author = {G R R Martin},
-	date-added = {2022-11-17 09:28:28 -0500},
-	date-modified = {2022-11-17 09:29:09 -0500},
-	publisher = {{HarperVoyager}},
-	title = {A song of fire and ice},
-	year = {2012}}
+	month = {November},
+	publisher = {Voyager Books},
+	series = {A Song of Ice and Fire},
+	title = {A {C}lash of {K}ings},
+	year = {1998}}
 
 @techreport{Shan20,
 	author = {M Shannon},

--- a/cdl.bib
+++ b/cdl.bib
@@ -27,8 +27,7 @@
 	howpublished = {\url{https://github.com/tqdm/tqdm}},
 	month = {September},
 	title = {{tqdm}: A {F}ast, {E}xtensible {P}rogress {B}ar for {P}ython and {CLI}},
-	year = {2022},
-	bdsk-url-1 = {https://doi.org/10.5281/zenodo.595120}}
+	year = {2022}}
 
 @misc{FredEtal15,
 	author = {J Frederic and J Grout and {Jupyter Widgets Contributors}},
@@ -46,8 +45,7 @@
 	pages = {861},
 	title = {{UMAP}: {U}niform {M}anifold {A}pproximation and {P}rojection},
 	volume = {3},
-	year = {2018},
-	bdsk-url-1 = {https://doi.org/10.21105/joss.00861}}
+	year = {2018}}
 
 @misc{Varo10,
 	author = {Ga\"{e}l Varoquaux},
@@ -87,8 +85,7 @@
 	month = {May},
 	publisher = {Zenodo},
 	title = {{ContextLab/experimental-psychology: v1.0 (Spring, 2022)}},
-	year = {2022},
-	bdsk-url-1 = {https://doi.org/10.5281/zenodo.6596762}}
+	year = {2022}}
 
 @article{GaoEtal20,
 	author = {Gao, Leo and Biderman, Stella and Black, Sid and Golding, Laurence and Hoppe, Travis and Foster, Charles and Phang, Jason and He, Horace and Thite, Anish and Nabeshima, Noa and Presser, Shawn and Leahy, Connor},
@@ -115,8 +112,7 @@
 	publisher = {Association for Computing Machinery},
 	title = {Programming {T}echniques: {R}egular expression search algorithm},
 	volume = {11},
-	year = {1968},
-	bdsk-url-1 = {https://doi.org/10.1145/363347.363387}}
+	year = {1968}}
 
 @misc{cond15,
 	author = {conda-forge community},
@@ -126,8 +122,7 @@
 	month = {July},
 	publisher = {Zenodo},
 	title = {{The conda-forge Project: Community-based Software Distribution Built on the conda Package Format and Ecosystem}},
-	year = {2015},
-	bdsk-url-1 = {https://doi.org/10.5281/zenodo.4774217}}
+	year = {2015}}
 
 @techreport{CoghStuf13,
 	author = {Nick Coghlan and Donald Stufft},
@@ -180,8 +175,7 @@
 	pages = {115--138},
 	title = {Virtual {M}achine {T}ool},
 	volume = {54},
-	year = {2005},
-	bdsk-url-1 = {https://doi.org/10.1016/S0007-8506(07)60022-5}}
+	year = {2005}}
 
 @misc{AbadEtal15,
 	author = {Mart\'{i}n~Abadi and Ashish~Agarwal and Paul~Barham and Eugene~Brevdo and Zhifeng~Chen and Craig~Citro and Greg~S.~Corrado and Andy~Davis and Jeffrey~Dean and Matthieu~Devin and Sanjay~Ghemawat and Ian~Goodfellow and Andrew~Harp and Geoffrey~Irving and Michael~Isard and Yangqing Jia and Rafal~Jozefowicz and Lukasz~Kaiser and Manjunath~Kudlur and Josh~Levenberg and Dandelion~Man\'{e} and Rajat~Monga and Sherry~Moore and Derek~Murray and Chris~Olah and Mike~Schuster and Jonathon~Shlens and Benoit~Steiner and Ilya~Sutskever and Kunal~Talwar and Paul~Tucker and Vincent~Vanhoucke and Vijay~Vasudevan and Fernanda~Vi\'{e}gas and Oriol~Vinyals and Pete~Warden and Martin~Wattenberg and Martin~Wicke and Yuan~Yu and Xiaoqiang~Zheng},
@@ -189,8 +183,7 @@
 	note = {Software available from tensorflow.org},
 	title = {{TensorFlow: Large-Scale Machine Learning on Heterogeneous Systems}},
 	url = {https://www.tensorflow.org/},
-	year = {2015},
-	bdsk-url-1 = {https://www.tensorflow.org/}}
+	year = {2015}}
 
 @article{GranGrou16,
 	author = {B Granger and J Grout},
@@ -207,8 +200,7 @@
 	pages = {357--362},
 	title = {Array programming with {NumPy}},
 	volume = {585},
-	year = {2020},
-	bdsk-url-1 = {https://doi.org/10.1038/s41586-020-2649-2}}
+	year = {2020}}
 
 @article{KurtEtal17,
 	author = {Gregory M Kurtzer and Vanessa Sochat and Michael W Bauer},
@@ -229,8 +221,7 @@
 	pages = {87--90},
 	publisher = {{IOS} Press},
 	title = {Jupyter {N}otebooks -- a publishing format for reproducible computational workflows},
-	year = {2016},
-	bdsk-url-1 = {https://doi.org/10.3233/978-1-61499-649-1-87}}
+	year = {2016}}
 
 @misc{Mann21e,
 	author = {J R Manning},
@@ -239,8 +230,7 @@
 	howpublished = {\url{https://github.com/ContextLab/abstract2paper}},
 	month = {June},
 	title = {{abstract2paper}},
-	year = {2021},
-	bdsk-url-1 = {https://doi.org/10.5281/zenodo.7261831}}
+	year = {2021}}
 
 @misc{Mann21d,
 	author = {J R Manning},
@@ -249,8 +239,7 @@
 	month = {June},
 	publisher = {Zenodo},
 	title = {Storytelling with {D}ata},
-	year = {2021},
-	bdsk-url-1 = {https://doi.org/10.5281/zenodo.5182775}}
+	year = {2021}}
 
 @article{Merk14,
 	author = {Dirk Merkel},
@@ -269,8 +258,7 @@
 	pages = {11},
 	title = {{Python} in neuroscience},
 	volume = {9},
-	year = {2015},
-	bdsk-url-1 = {https://doi.org/10.3389/fninf.2015.00011}}
+	year = {2015}}
 
 @article{PereGran07,
 	author = {F P{\'e}rez and B E Granger},
@@ -280,8 +268,7 @@
 	pages = {21--29},
 	title = {I{P}ython: a system for interactive scientific computing},
 	volume = {9},
-	year = {2007},
-	bdsk-url-1 = {https://doi.org/10.1109/MCSE.2007.53}}
+	year = {2007}}
 
 @inproceedings{RagaWill18,
 	author = {Benjamin Ragan-Kelley and Carol Willing},
@@ -290,8 +277,7 @@
 	editor = {F Akici and D Lippa and D Niederhut and M Pacer},
 	pages = {113--120},
 	title = {Binder 2.0-{R}eproducible, interactive, sharable environments for science at scale},
-	year = {2018},
-	bdsk-url-1 = {https://doi.org/10.25080/MAJORA-4AF1F417-011}}
+	year = {2018}}
 
 @article{vanR95,
 	author = {Guido {van Rossum}},
@@ -319,8 +305,7 @@
 	pages = {261--272},
 	title = {{{SciPy} 1.0: Fundamental Algorithms for Scientific Computing in Python}},
 	volume = {17},
-	year = {2020},
-	bdsk-url-1 = {https://doi.org/10.1038/s41592-019-0686-2}}
+	year = {2020}}
 
 @article{Wask21,
 	author = {Michael L Waskom},
@@ -330,8 +315,7 @@
 	pages = {3021},
 	title = {{s}eaborn: statistical data visualization},
 	volume = {6},
-	year = {2021},
-	bdsk-url-1 = {https://doi.org/10.21105/joss.03021}}
+	year = {2021}}
 
 @inproceedings{WolfEtal20,
 	author = {Thomas Wolf and Lysandre Debut and Victor Sanh and Julien Chaumond and Clement Delangue and Anthony Moi and Perric Cistac and Clara Ma and Yacine Jernite and Julien Plu and Canwen Xu and Teven {Le Scao} and Sylvain Gugger and Mariama Drame and Quentin Lhoest and Alexander M Rush},
@@ -7135,8 +7119,7 @@
 	editor = {St\'efan van der Walt and Jarrod Millman},
 	pages = {56--61},
 	title = {Data {S}tructures for {S}tatistical {C}omputing in {P}ython},
-	year = {2010},
-	bdsk-url-1 = {https://doi.org/10.25080/Majora-92bf1922-00a}}
+	year = {2010}}
 
 @article{PedrEtal11,
 	author = {F Pedregosa and G Varoquaux and A Gramfort and V Michel and B Thirion and O Grisel and M Blondel and P Prettenhofer and R Weiss and V Dubourg and J Vanderplas and A Passos and D Cournapeau and M Brucher and M Perrot and E Duchesnay},
@@ -7154,8 +7137,7 @@
 	pages = {90--95},
 	title = {Matplotlib: A {2D} graphics environment},
 	volume = {9},
-	year = {2007},
-	bdsk-url-1 = {https://doi.org/10.1109/MCSE.2007.55}}
+	year = {2007}}
 
 @article{vandHint08,
 	author = {L J P van der Maaten and G E Hinton},


### PR DESCRIPTION
### List of citation keys added (one per line)

### List of citation keys modified (one per line)
- Mart12 ➡️ Mart98
### Other changes (describe)
- removed fields automatically added by BibDesk (bdsk-url-1, date-added, date-modified, etc.)
- added "series" to keep_fields.txt (used for books)