### PR TITLE
small fixes to Mart98, HeusEtal21

### DIFF
--- a/cdl.bib
+++ b/cdl.bib
@@ -5747,7 +5747,7 @@
 	author = {A C Heusser and P C Fitzpatrick and J R Manning},
 	journal = {Nature Human Behavior},
 	pages = {905--919},
-	title = {Geometric models reveal behavioral and neural signatures of transforming naturalistic experiences into episodic memories},
+	title = {Geometric models reveal behavioral and neural signatures of transforming experiences into memories},
 	volume = {5},
 	year = {2021}}
 


### PR DESCRIPTION
### List of citation keys added (one per line)
N/A

### List of citation keys modified (one per line)
- Mart98 -- fix from ContextLab/davos@556539f was never merged in this repo
- HeusEtal21 -- fixed title (existing title was from last pre-publication preprint version)

### Other changes (describe)
- add "series" to `keep_fields.txt` (needed for books in a series, e.g., Mart98)