### PR TITLE
Add 11 named-system refs for the Kiewit companion whitepaper

### DIFF
--- a/cdl.bib
+++ b/cdl.bib
@@ -143,7 +143,7 @@
 	Volume = {232},
 	Year = {2023}}
 
-@article{ChenEtal24,
+@article{ChenEtal24a,
 	Author = {A M Chen and A Palacci and N V{\'e}lez and R D Hawkins and S J Gershman},
 	Journal = {Cognitive Science},
 	Number = {7},
@@ -53461,4 +53461,93 @@
  journal = {Transactions on Machine Learning Research},
  title = {When are two scores better than one? investigating ensembles of diffusion models},
  year = {2026}
+}
+@article{XieEtal25,
+ author = {Z Xie and J Ye and L Zheng and J Gao and J Dong and Z Wu and X Zhao and S Gong and X Jiang and Z Li and L Kong},
+ journal = {{arXiv}},
+ title = {{Dream-Coder 7B}: an open diffusion language model for code},
+ volume = {doi.org/10.48550/arXiv.2509.01142},
+ year = {2025}
+}
+
+@article{LiuEtal24,
+ author = {A Liu and B Feng and B Xue and B Wang and B Wu and C Lu and C Zhao and C Deng and C Zhang and C Ruan and D Dai and D Guo and D Yang and D Chen and others},
+ journal = {{arXiv}},
+ title = {{DeepSeek-V3} technical report},
+ volume = {doi.org/10.48550/arXiv.2412.19437},
+ year = {2024}
+}
+
+@article{GongEtal25,
+ author = {S Gong and S Agarwal and Y Zhang and J Ye and L Zheng and M Li and C An and P Zhao and W Bi and J Han and H Peng and L Kong},
+ journal = {{arXiv}},
+ title = {Scaling diffusion language models via adaptation from autoregressive models},
+ volume = {doi.org/10.48550/arXiv.2410.17891},
+ year = {2025}
+}
+
+@article{KhanEtal25,
+ author = {S Khanna and S Kharbanda and S Li and H Varma and E Wang and S Birnbaum and Z Luo and Y Miraoui and A Palrecha and S Ermon and A Grover and V Kuleshov},
+ journal = {{arXiv}},
+ title = {Mercury: ultra-fast language models based on diffusion},
+ volume = {doi.org/10.48550/arXiv.2506.17298},
+ year = {2025}
+}
+
+@article{JainEtal24,
+ author = {N Jain and K Han and A Gu and W-D Li and F Yan and T Zhang and S Wang and A Solar-Lezama and K Sen and I Stoica},
+ journal = {{arXiv}},
+ title = {{LiveCodeBench}: holistic and contamination free evaluation of large language models for code},
+ volume = {doi.org/10.48550/arXiv.2403.07974},
+ year = {2024}
+}
+
+@article{YangEtal24,
+ author = {A Yang and B Yang and B Zhang and B Hui and B Zheng and B Yu and C Li and D Liu and F Huang and H Wei and others},
+ journal = {{arXiv}},
+ title = {{Qwen2.5} technical report},
+ volume = {doi.org/10.48550/arXiv.2412.15115},
+ year = {2024}
+}
+
+@article{TangEtal24,
+ author = {Z Tang and J Tang and H Luo and F Wang and T-H Chang},
+ journal = {Proceedings of the 41st International Conference on Machine Learning},
+ pages = {47800--47818},
+ title = {Accelerating parallel sampling of diffusion models},
+ volume = {235},
+ year = {2024}
+}
+
+@article{ChenEtal24b,
+ author = {H Chen and Y Ren and L Ying and G M Rotskoff},
+ journal = {Advances in Neural Information Processing Systems},
+ pages = {126955--126983},
+ title = {Accelerating diffusion models with parallel sampling: inference at sub-linear time complexity},
+ volume = {37},
+ year = {2024}
+}
+
+@article{ChenEtal24c,
+ author = {Z Chen and X Ma and G Fang and Z Tan and X Wang},
+ journal = {Advances in Neural Information Processing Systems},
+ title = {{AsyncDiff}: parallelizing diffusion models by asynchronous denoising},
+ volume = {37},
+ year = {2024}
+}
+
+@article{FangEtal24,
+ author = {J Fang and J Pan and X Sun and A Li and J Wang},
+ journal = {{arXiv}},
+ title = {{xDiT}: an inference engine for diffusion transformers with massive parallelism},
+ volume = {doi.org/10.48550/arXiv.2411.01738},
+ year = {2024}
+}
+
+@article{YangEtal25,
+ author = {W Yang and J Liu and S Wang and X Song and L Ai and E Yang and B Shi},
+ journal = {{arXiv}},
+ title = {{Lattica}: a decentralized cross-{NAT} communication framework for scalable {AI} inference and training},
+ volume = {doi.org/10.48550/arXiv.2510.00183},
+ year = {2025}
 }


### PR DESCRIPTION
Second tranche of entries for the Kiewit Provost Leadership Fellows application. All 11 were individually web-verified against primary sources (arXiv, NeurIPS/ICML proceedings) and pass bibcheck verify.

Also renames the pre-existing entry:
  ChenEtal24 (A M Chen et al., 2024, hierarchical Bayesian model
  of adaptive teaching, Cognitive Science 48:7) -> ChenEtal24a
per bibcheck's suffix-on-collision rule. This rename lands *before* either of the two new Chen-led 2024 papers (ChenEtal24b, ChenEtal24c) is added, so all three keys are unique at every point of the commit history.

Downstream CDL documents currently citing \citep{ChenEtal24} will need to update to \citep{ChenEtal24a}. This is the standard CDL procedure for suffix collisions (see historical precedents in the log: MikoEtal13 -> MikoEtal13a, RichEtal14 -> RichEtal14a, BateEtal15 -> BateEtal15a, McInEtal18 -> McInEtal18a, MayeEtal92 -> MayeEtal92a).

New entries (all arXiv-verified; details in the whitepaper commit that cites them):

  Diffusion LMs / coding:
    XieEtal25   Dream-Coder 7B                    arXiv:2509.01142
    LiuEtal24   DeepSeek-V3 tech report           arXiv:2412.19437
    GongEtal25  DiffuLLaMA / DiffuGPT (ICLR '25)  arXiv:2410.17891
    KhanEtal25  Mercury (Inception Labs)          arXiv:2506.17298
    JainEtal24  LiveCodeBench                     arXiv:2403.07974

  Base models:
    YangEtal24  Qwen2.5 technical report          arXiv:2412.15115
    (Llama 3 reuses existing cdl.bib entry SingEtal24)

  Parallel-diffusion systems:
    TangEtal24  ParaTAA (ICML 2024)               arXiv:2402.09970
    ChenEtal24b Sub-linear parallel diffusion
                sampling (NeurIPS 2024 Spotlight) arXiv:2405.15986
    ChenEtal24c AsyncDiff (NeurIPS 2024)          arXiv:2406.06911
    FangEtal24  xDiT                              arXiv:2411.01738

  Networking:
    YangEtal25  Lattica cross-NAT AI mesh         arXiv:2510.00183

Systems referenced in the whitepaper that have NO citable primary source and will therefore be prose-softened rather than cited:

  - EAT edge-scheduling framework (no pre-2025 paper under that name matches the whitepaper's usage)
  - libp2p (project specs only, no formal paper; DCUtR is already covered by TrauEtal25)

Integrity check: python bibcheck.py verify cdl.bib -> "looks good!" (6203 entries total, up from the earlier 6192).

### List of citation keys added (one per line)

### List of citation keys modified (one per line)

### Other changes (describe)
