### PR TITLE
Strip malformed @comment{...} blocks from cdl.bib (fixes bibtex breakage)

### DIFF
--- a/cdl.bib
+++ b/cdl.bib
@@ -53551,3 +53551,49 @@
  volume = {doi.org/10.48550/arXiv.2510.00183},
  year = {2025}
 }
+@comment{% Third tranche: volunteer-compute precedents for the Kiewit
+% whitepaper's "what is a volunteer mesh" section. Each entry
+% web-verified against primary sources and formatted to CDL
+% bibcheck verify conventions.
+
+% AndeEtal02: the canonical SETI@home paper. Verified via ACM DL
+% (DOI 10.1145/581571.581573) and author-hosted copy at
+% setiathome.berkeley.edu/sah_papers/cacm.php.}
+
+@comment{% Ande04: the canonical BOINC paper. Verified via ACM DL
+% (DOI 10.1109/GRID.2004.14) and the author-hosted PDF at
+% boinc.berkeley.edu/grid_paper_04.pdf. Single-author paper by
+% David P. Anderson.}
+
+@comment{% VoelEtal23: 20-year retrospective on Folding@home, treating it
+% as a canonical volunteer-compute precedent for exascale
+% biomolecular simulation. Verified via ScienceDirect
+% (DOI 10.1016/j.bpj.2023.03.028) and PMC PMC10398258.}
+
+@article{AndeEtal02,
+ author = {D P Anderson and J Cobb and E Korpela and M Lebofsky and D Werthimer},
+ journal = {Communications of the {ACM}},
+ number = {11},
+ pages = {56--61},
+ title = {{SETI@home}: an experiment in public-resource computing},
+ volume = {45},
+ year = {2002}
+}
+
+@article{Ande04,
+ author = {D P Anderson},
+ journal = {Proceedings of the 5th {IEEE} International Workshop on Grid Computing},
+ pages = {4--10},
+ title = {{BOINC}: a system for public-resource computing and storage},
+ year = {2004}
+}
+
+@article{VoelEtal23,
+ author = {V A Voelz and V S Pande and G R Bowman},
+ journal = {Biophysical Journal},
+ number = {14},
+ pages = {2852--2863},
+ title = {Folding@home: achievements from over 20 years of citizen science herald the exascale era},
+ volume = {122},
+ year = {2023}
+}

--- a/cdl.bib
+++ b/cdl.bib
@@ -53218,114 +53218,7 @@
 	Title = {Mixtures of {D}irichlet processes with applications to {B}ayesian nonparametric problems},
 	Volume = {2},
 	Year = {1974}}
-@comment{% References for the Kiewit PLF proposal and its companion whitepaper.
-% All entries below have been web-verified against their primary sources
-% (publisher pages, arXiv records, ACL Anthology, AAAI OJS, ACM DL,
-% NeurIPS proceedings, HUP / Open Library, PubMed) during the
-% preparation of this document. Formatting follows the CDL bibcheck
-% conventions documented at
-% https://github.com/ContextLab/CDL-bibliography#verify :
-%   - keys: Mann21 / MannKaha21 / MannEtal21 (with a/b suffixes on
-%     collision), using the *publication* year's last two digits.
-%   - authors: "F M Surname" form, " and "-separated.
-%   - standard fields only (doi / note / eprint are not in the
-%     keep_fields list and will be stripped by bibcheck on integration).
-%   - the arXiv-preprint convention in cdl.bib is:
-%       Journal = {{arXiv}}, Volume = {doi.org/10.48550/arXiv.NNNN.NNNNN}
-%
-% Verification notes (primary source URLs) are kept in comments
-% next to each entry so the audit trail is preserved when these
-% entries are merged upstream into cdl.bib.
 
-% ---------------------------------------------------------------
-% I. Historical Dartmouth references (proposal §2)
-% ---------------------------------------------------------------
-
-% KemeKurt68: Science 162(3850):223-228, DOI 10.1126/science.162.3850.223
-% Verified via PubMed PMID 5675464.}
-
-@comment{% Keme72: Book. Verified via Open Library OL5282840M and bookseller
-% records (ISBN 0684130432). Publisher is Charles Scribner's Sons.}
-
-@comment{% McCaEtal06: AI Magazine 27(4):12-14, 2006 reprint of the original
-% 31 August 1955 proposal. Verified by downloading the AAAI OJS PDF
-% (https://ojs.aaai.org/index.php/aimagazine/article/view/1904) and
-% reading the printed page numbers 12, 13, 14. DOI 10.1609/aimag.v27i4.1904.
-% Per bibcheck the key uses the *publication* year (2006), not the
-% 1955 original date.}
-
-@comment{% Rank18: Book. Verified via HUP catalog
-% https://www.hup.harvard.edu/books/9780674970977 and the De Gruyter
-% record for ISBN 9780674988538.}
-
-@comment{% Kurt81: Chapter in the ACM HOPL-I proceedings volume
-% (Wexelblat ed., Academic Press 1981). Verified via ACM DL
-% https://dl.acm.org/doi/10.1145/800025.1198404 ; pages 515-537
-% refer to Kurtz's chapter alone (the 515-549 span in some indexes
-% includes the subsequent session discussion by Cheatham). The
-% chapter's printed title is simply the acronym "BASIC"; bibcheck's
-% sentence-case rule would render it "Basic" which mangles the
-% acronym, so we use force = {True} to preserve the authoritative
-% printed title.}
-
-@comment{% ---------------------------------------------------------------
-% II. Systems / distributed-inference references
-% ---------------------------------------------------------------
-
-% KwonEtal23: SOSP 2023. Verified pages 611-626 and DOI
-% 10.1145/3600006.3613165 via dblp conf/sosp/KwonLZ0ZY0ZS23 and
-% ACM DL. 29th SOSP was held in Koblenz, Germany.}
-
-@comment{% LiEtal24: CVPR 2024 Highlight. Verified via CVPR 2024 Open Access:
-% https://openaccess.thecvf.com/content/CVPR2024/html/Li_DistriFusion_...
-% Full author list in publication order matches arXiv 2402.19481.}
-
-@comment{% HanEtal24: NAACL 2024 long paper. Verified via ACL Anthology
-% https://aclanthology.org/2024.naacl-long.464 , DOI
-% 10.18653/v1/2024.naacl-long.464 , pages 8385-8400.}
-
-@comment{% BorzEtal23a: Petals system demo at ACL 2023.
-% https://aclanthology.org/2023.acl-demo.54 , DOI
-% 10.18653/v1/2023.acl-demo.54 , pages 558-568, Toronto. "a" suffix
-% because of the second Borzunov 2023 entry (NeurIPS, see BorzEtal23b).}
-
-@comment{% BorzEtal23b: Distinct follow-up paper at NeurIPS 2023 (Poster, not
-% Spotlight). Verified via NeurIPS proceedings
-% https://proceedings.neurips.cc/paper_files/paper/2023/hash/28bf1419b9a1f908c15f6195f58cb865-Abstract-Conference.html
-% and arXiv 2312.08361 . Author list uses "Ryabinin" (the
-% transliteration the authors themselves use in this paper; the ACL
-% demo above uses "Riabinin").}
-
-@comment{% ShihEtal23: NeurIPS 2023 Spotlight. Verified via
-% https://proceedings.neurips.cc/paper_files/paper/2023/hash/0d1986a61e30e5fa408c81216a616e20-Abstract-Conference.html
-% pages 4263-4276 in Adv. Neural Inf. Process. Syst. vol. 36. The
-% "ParaDiGMS" name is the project name; the paper's title itself is
-% "Parallel Sampling of Diffusion Models".}
-
-@comment{% ---------------------------------------------------------------
-% III. Diffusion-LM references
-% ---------------------------------------------------------------
-
-% YeEtal25: arXiv preprint (no venue acceptance as of April 2026
-% verification). Author list verified in order against arXiv abs/2508.15487.
-% The author surname "Ye" is 2 letters, yielding the short key "YeEtal25".}
-
-@comment{% NieEtal25: arXiv preprint (no venue acceptance as of April 2026
-% verification). Ten-author list verified against arXiv abs/2502.09992.}
-
-@comment{% TrauEtal25: arXiv preprint. The original refs.bib entry abbreviated
-% the author list with "and others"; the full 4-author list is
-% verified against arXiv abs/2510.27500 . Title uses "--" (en-dash)
-% as rendered by arXiv (not "---" / em-dash).}
-
-@comment{% BradNakk25: TMLR 2025. Two authors: "BradNakk25" key. Verified
-% via arXiv abs/2408.09000 and TMLR/OpenReview (forum id zrWNtzSZsf).
-% TMLR does not assign volume/issue/pages.}
-
-@comment{% RazaEtal26: TMLR 2026 (accepted February 2026). Verified via
-% arXiv abs/2601.11444 and TMLR/OpenReview (forum id 4iRx9b0Csu).
-% Full title includes the subtitle "Investigating Ensembles of
-% Diffusion Models" which the whitepaper draft had omitted.}
 
 @article{KemeKurt68,
  author = {J G Kemeny and T E Kurtz},
@@ -53551,25 +53444,6 @@
  volume = {doi.org/10.48550/arXiv.2510.00183},
  year = {2025}
 }
-@comment{% Third tranche: volunteer-compute precedents for the Kiewit
-% whitepaper's "what is a volunteer mesh" section. Each entry
-% web-verified against primary sources and formatted to CDL
-% bibcheck verify conventions.
-
-% AndeEtal02: the canonical SETI@home paper. Verified via ACM DL
-% (DOI 10.1145/581571.581573) and author-hosted copy at
-% setiathome.berkeley.edu/sah_papers/cacm.php.}
-
-@comment{% Ande04: the canonical BOINC paper. Verified via ACM DL
-% (DOI 10.1109/GRID.2004.14) and the author-hosted PDF at
-% boinc.berkeley.edu/grid_paper_04.pdf. Single-author paper by
-% David P. Anderson.}
-
-@comment{% VoelEtal23: 20-year retrospective on Folding@home, treating it
-% as a canonical volunteer-compute precedent for exascale
-% biomolecular simulation. Verified via ScienceDirect
-% (DOI 10.1016/j.bpj.2023.03.028) and PMC PMC10398258.}
-
 @article{AndeEtal02,
  author = {D P Anderson and J Cobb and E Korpela and M Lebofsky and D Werthimer},
  journal = {Communications of the {ACM}},


### PR DESCRIPTION
## Summary

PR #74, #75, and #76 inadvertently introduced \`@comment{...}\` blocks into \`cdl.bib\` via bibtexparser's serialization. bibtex's parser chokes on the embedded URLs and commas inside those blocks (the \"Folding@home, treating it\" pattern is the most direct trigger), causing exit-code-2 failures for any downstream document that runs bibtex against master.

This PR strips all \`@comment{...}\` blocks from \`cdl.bib\` so it parses cleanly again.

## What changed

- 127 lines of \`@comment{...}\` blocks removed (audit-trail comments left over from PRs #74/#75/#76).
- 1 line trailing newline cleanup.

## Why @comment isn't the right tool here

bibtex parses \`@comment{...}\` looking for balanced braces, but it does so character-by-character without robustly handling commas, embedded \`@\` characters (e.g. \`Folding@home\`), or URL-style \`{...}\` nesting. A line like:

\`\`\`
@comment{% VoelEtal23: 20-year retrospective on Folding@home, treating it
% as a canonical volunteer-compute precedent...
\`\`\`

makes bibtex skip the rest of the entry, which then breaks any document that cites entries appearing later in the file.

The audit-trail content those comments carried is preserved in the merged PR descriptions and the submodule commit messages, which is the correct place for that history.

## Verification

\`\`\`
python bibcheck.py verify cdl.bib  ->  looks good!  (6206 entries)
bibtex (against a downstream document)  ->  exit 0, no errors
\`\`\`

## Test plan

- [x] \`python bibcheck.py verify cdl.bib\` passes
- [x] \`bibtex\` succeeds against a downstream document that cites entries from the affected ranges
- [x] No bib entries removed; only \`@comment\` blocks
- [x] Diff is purely deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)