### PR TITLE
Update CI actions for Node 20 deprecation (checkout@v4, setup-python@v5)

### DIFF
--- a/.github/workflows/autocheck.yml
+++ b/.github/workflows/autocheck.yml
@@ -20,10 +20,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: '3.9'
       - name: install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary

Bumps `actions/checkout@v2` → `@v4` and `actions/setup-python@v2` → `@v5` in the autocheck workflow.

The post-merge CI run for PR #79 emitted this warning:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v2, actions/setup-python@v2. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026.

That deadline is 5 days away, so updating now keeps autocheck green. Also quotes the `python-version` value (`'3.9'`) per YAML best practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
