### PR TITLE
Add 11 refs for the memory-dynamics paper; suffix WangEtal10

### DIFF
--- a/cdl.bib
+++ b/cdl.bib
@@ -16577,8 +16577,8 @@
 	Volume = {23},
 	Year = {2011}}
 
-@article{WangEtal10,
-	Author = {Y Wang and Q J Zhang and U Ali and Z H Gui and Y P Hui and L Chen and T Wang},
+@article{WangEtal10a,
+	Author = {Y Wang and Q J Zhang and J Liu and U Ali and Z H Gui and Y P Hui and L Chen and T Wang},
 	Journal = {Brain Research},
 	Pages = {54--63},
 	Title = {Changes in firing rate and pattern of {GABA-ergic} neurons in subregions of the {Substantia Nigra} pars reticulata in rat models of {Parkinson's Disease}},
@@ -54358,3 +54358,96 @@
 	Howpublished = {\url{http://dartnets.cs.dartmouth.edu/career}},
 	Title = {Dartmouth Networking and Systems ({DartNets}) Lab --- {NSF} {CAREER} research},
 	Year = {2025}}
+
+@article{Vite67,
+	Author = {A J Viterbi},
+	Journal = {{IEEE} Transactions on Information Theory},
+	Number = {2},
+	Pages = {260--269},
+	Title = {Error bounds for convolutional codes and an asymptotically optimum decoding algorithm},
+	Volume = {13},
+	Year = {1967}}
+
+@article{BaumEtal70,
+	Author = {L E Baum and T Petrie and G Soules and N Weiss},
+	Journal = {Annals of Mathematical Statistics},
+	Number = {1},
+	Pages = {164--171},
+	Title = {A maximization technique occurring in the statistical analysis of probabilistic functions of {M}arkov chains},
+	Volume = {41},
+	Year = {1970}}
+
+@article{BaumPetr66,
+	Author = {L E Baum and T Petrie},
+	Journal = {Annals of Mathematical Statistics},
+	Number = {6},
+	Pages = {1554--1563},
+	Title = {Statistical inference for probabilistic functions of finite state {M}arkov chains},
+	Volume = {37},
+	Year = {1966}}
+
+@article{VeraEtal25,
+	Author = {H S Vera and S Dua and B Zhang and D Salz and R Mullins and S R Panyam and S Smoot and I Naim and J Zou and F Chen and D Cer and A Lisak and M Choi and L Gonzalez and O Sanseviero and G Cameron and I Ballantyne and K Black and K Chen and W Wang and Z Li and G Martins and J Lee and M Sherwood and J Ji and R Wu and J Zheng and J Singh and A Sharma and D Sreepathihalli and A Jain and A Elarabawy and A Co and A Doumanoglou and B Samari and B Hora and B Potetz and D Kim and E Alfonseca and F Moiseev and F Han and F P Gomez and G H {\'A}brego and H Zhang and H Hui and J Han and K Gill and K Chen and K Chen and M Shanbhogue and M Boratko and P Suganthan and S M K Duddu and S Mariserla and S Ariafar and S Zhang and S Zhang and S Baumgartner and S Goenka and S Qiu and T Dabral and T Walker and V Rao and W Khawaja and W Zhou and X Ren and Y Xia and Y Chen and Y-T Chen and Z Dong and Z Ding and F Visin and G Liu and J Zhang and K Kenealy and M Casbon and R Kumar and T Mesnard and Z Gleicher and C Brick and O Lacombe and A Roberts and Q Yin and Y Sung and R Hoffmann and T Warkentin and A Joulin and T Duerig and M Seyedhosseini},
+	Journal = {{arXiv}},
+	Title = {{EmbeddingGemma}: powerful and lightweight text representations},
+	Year = {2025}}
+
+@inproceedings{StonEtal25,
+	Address = {New York, {NY}, {USA}},
+	Author = {S Stone and J Crossett and T Luker and L Leligdon and W Cowen and C Darabos},
+	Booktitle = {Practice and Experience in Advanced Research Computing 2025: the Power of Collaboration},
+	Pages = {1--5},
+	Publisher = {Association for Computing Machinery},
+	Title = {Dartmouth {C}hat - deploying an open-source {LLM} stack at scale},
+	Year = {2025}}
+
+@misc{Qwen26,
+	Author = {{Qwen Team}},
+	Howpublished = {\url{https://qwen.ai/blog?id=qwen3.5}},
+	Title = {Qwen3.5: towards native multimodal agents},
+	Year = {2026}}
+
+@inproceedings{WangEtal10b,
+	Address = {Dallas, {TX}, {USA}},
+	Author = {W Wang and G Tur and J Zheng and N F Ayan},
+	Booktitle = {2010 {IEEE} International Conference on Acoustics, Speech and Signal Processing},
+	Pages = {5214--5217},
+	Title = {Automatic disfluency removal for improving spoken language translation},
+	Year = {2010}}
+
+@inproceedings{ChenEtal22,
+	Address = {Seattle, United States},
+	Author = {A Chen and V Zayats and D Walker and D Padfield},
+	Booktitle = {Proceedings of the 2022 Conference of the North {American} Chapter of the Association for Computational Linguistics: Human Language Technologies},
+	Editor = {M Carpuat and M C de Marneffe and I V Meza Ruiz},
+	Pages = {827--838},
+	Publisher = {Association for Computational Linguistics},
+	Title = {Teaching {BERT} to wait: balancing accuracy and latency for streaming disfluency detection},
+	Year = {2022}}
+
+@article{FitzEtal26,
+	Author = {P C Fitzpatrick and A C Heusser and J R Manning},
+	Journal = {Nature Communications},
+	Number = {1},
+	Pages = {2955},
+	Title = {Text embedding models yield detailed conceptual knowledge maps derived from short multiple-choice quizzes},
+	Volume = {17},
+	Year = {2026}}
+
+@article{Vint68,
+	Author = {T K Vintsyuk},
+	Journal = {Cybernetics},
+	Number = {1},
+	Pages = {52--57},
+	Title = {Speech discrimination by dynamic programming},
+	Volume = {4},
+	Year = {1968}}
+
+@article{SakoChib78,
+	Author = {H Sakoe and S Chiba},
+	Journal = {{IEEE} Transactions on Acoustics, Speech, and Signal Processing},
+	Number = {1},
+	Pages = {43--49},
+	Title = {Dynamic programming algorithm optimization for spoken word recognition},
+	Volume = {26},
+	Year = {1978}}


### PR DESCRIPTION
### List of citation keys added (one per line)
Vite67
BaumPetr66
BaumEtal70
Vint68
SakoChib78
WangEtal10b
ChenEtal22
VeraEtal25
StonEtal25
FitzEtal26
Qwen26

### List of citation keys modified (one per line)
WangEtal10 (renamed to WangEtal10a; also restored a missing author)

### Other changes (describe)

**Context.** These are the references cited by the in-preparation ContextLab
memory-dynamics paper that were not yet in `cdl.bib`.

**Verification.** Every field of every entry was fact-checked against primary
sources before submission — CrossRef, PubMed/NCBI, arXiv, OpenAlex, Semantic
Scholar, and dblp — rather than transcribed from a reference manager. Details:

| Key | Verified against |
|-|-|
| `Vite67` | CrossRef + dblp |
| `BaumPetr66`, `BaumEtal70` | CrossRef |
| `Vint68` | CrossRef + publisher listing (see note below) |
| `SakoChib78` | CrossRef |
| `WangEtal10b` | CrossRef |
| `ChenEtal22` | CrossRef |
| `VeraEtal25` | arXiv:2509.20354 (all 89 authors checked in order) |
| `StonEtal25` | CrossRef + OpenAlex + Semantic Scholar |
| `FitzEtal26` | CrossRef |
| `Qwen26` | Publisher blog post + independent dated coverage |

**`WangEtal10` → `WangEtal10a` (breaking).** `WangEtal10b` now shares this base
key, and both the key convention and CONTRIBUTING step 3 require every key
sharing a base to carry a suffix. Any document currently citing `WangEtal10`
will need updating.

**Missing author restored in that same entry.** `WangEtal10a` listed 7 authors;
CrossRef (`10.1016/j.brainres.2010.02.008`) and PubMed (PMID 20149784) both list
8. Jian Liu (3rd author) was missing and has been restored. This is a factual
correction that formatting checks cannot detect.

**Note on `Vint68`.** CrossRef and OpenAlex both report `issued: 1972` for
`10.1007/BF01074755`. That is the Springer digitization date for the English
translation. The standard citation is *Cybernetics* 4(1):52-57 (1968), with the
Russian original in *Kibernetika* 4:81-88 (1968), so `Year = {1968}` is used
here — consistent with the `Vint68` key.

**Two entries deliberately NOT added.** A few refs in the source paper turned out
to already exist here under suffixed keys (`ChenEtal24a`, `MikkEtal17a`,
`MontEtal18a`, `NguyEtal16a`, `TianEtal20a`, `WoodEtal00a`). Those were dropped
from this PR rather than duplicated.

**Checks.** `python bibcheck.py verify` passes on the added entries, and the
full-file CI check (`python bibcheck/test.py`) exits 0 on the merged file: no
duplicate keys, no duplicate author/title pairs, no formatting errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)