### PR TITLE
Correct HeusEtal21 title spelling and add missing issue number

### DIFF
--- a/cdl.bib
+++ b/cdl.bib
@@ -6586,8 +6586,9 @@
 @article{HeusEtal21,
 	Author = {A C Heusser and P C Fitzpatrick and J R Manning},
 	Journal = {Nature Human Behaviour},
+	Number = {7},
 	Pages = {905--919},
-	Title = {Geometric models reveal behavioral and neural signatures of transforming experiences into memories},
+	Title = {Geometric models reveal behavioural and neural signatures of transforming experiences into memories},
 	Volume = {5},
 	Year = {2021}}
 


### PR DESCRIPTION
### List of citation keys added (one per line)
(none)

### List of citation keys modified (one per line)
HeusEtal21

### Other changes (describe)

Two small corrections to one entry, both verified against primary sources.

**1. `behavioral` → `behavioural`.** The published title uses the British
spelling — unsurprisingly, since the journal is *Nature Human Behaviour*.

**2. Added the missing issue number** (`Number = {7}`).

CrossRef (`10.1038/s41562-021-01051-6`) and PubMed (PMID 33574605) agree
independently:

> Geometric models reveal behavioural and neural signatures of transforming
> experiences into memories — *Nature Human Behaviour* **5**(7), 905–919, 2021

**Why this is a fix and not a normalization.** Worth stating explicitly, since
"correcting" a spelling in a shared bibliography could easily be the wrong call:
`cdl.bib` already preserves source spelling in titles rather than Americanizing
them — 11 titles contain "behaviour" and 6 contain "behavioural", alongside 41
that use "behavioral" because that is what those papers were published with. So
this entry was inconsistent with the file's existing practice, not conforming to
it.

Neither error is detectable by `bibcheck.py` — one is a spelling difference
inside a valid sentence-case title, the other a field that is optional. Both
were noticed while cross-checking references for the memory-dynamics paper.

**Checks.** Full-file `python bibcheck/test.py` exits 0: no duplicate keys, no
duplicate author/title pairs, no formatting errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)