### PR TITLE
Fix 6 entries and add 4 refs for the memory-dynamics introduction

### DIFF
--- a/cdl.bib
+++ b/cdl.bib
@@ -722,7 +722,7 @@
 	Volume = {18},
 	Year = {2008}}
 
-@incollection{Mann23a,
+@incollection{Mann23,
 	Author = {J R Manning},
 	Booktitle = {Intracranial {EEG}: a guide for cognitive neuroscientists},
 	Editor = {N Axmacher},
@@ -749,12 +749,14 @@
 	Title = {Feature and order manipulations in a free recall task affect memory for current and future lists},
 	Year = {2023}}
 
-@article{OwenMann23,
+@article{OwenMann24,
 	Author = {L L W Owen and J R Manning},
-	Journal = {{bioRxiv}},
-	Pages = {doi.org/10.1101/2023.03.17.53315},
+	Journal = {Proceedings of the National Academy of Sciences, {USA}},
+	Number = {35},
+	Pages = {e2400082121},
 	Title = {High-level cognition is supported by information-rich but compressible brain activity patterns},
-	Year = {2023}}
+	Volume = {121},
+	Year = {2024}}
 
 @article{PimeEtal19,
 	Author = {J F Pimentel and L Murta and V Braganholo and J Freire},
@@ -3652,8 +3654,10 @@
 @article{TianEtal20a,
 	Author = {Y Tian and D S Margulies and M Breakspear and A Zalesky},
 	Journal = {Nature Neuroscience},
+	Number = {11},
+	Pages = {1421--1432},
 	Title = {Topographic organization of the human subcortex unveiled with functional connectivity gradients},
-	Volume = {doi.org/10.1038/s41593-020-00711-6},
+	Volume = {23},
 	Year = {2020}}
 
 @article{ArzyScha19,
@@ -3948,13 +3952,13 @@
 	Volume = {216},
 	Year = {2020}}
 
-@incollection{Mann23b,
+@incollection{Mann24,
 	Author = {J R Manning},
-	Booktitle = {Handbook of Human Memory},
+	Booktitle = {The {Oxford} Handbook of Human Memory},
 	Editor = {M J Kahana and A D Wagner},
 	Publisher = {{Oxford} {University} Press},
 	Title = {Context reinstatement},
-	Year = {2023}}
+	Year = {2024}}
 
 @article{TalmEtal19,
 	Author = {D Talmi and L J Lohnas and N D Daw},
@@ -18336,11 +18340,11 @@
 	Year = {2011}}
 
 @incollection{Kaha00,
-	Address = {England, {UK}},
+	Address = {New York, {NY}},
 	Author = {M J Kahana},
-	Booktitle = {{Oxford} Handbook of Human Memory},
+	Booktitle = {The {Oxford} Handbook of Memory},
 	Editor = {E Tulving and F I M Craik},
-	Pages = {323--384},
+	Pages = {59--74},
 	Publisher = {{Oxford} {University} Press},
 	Title = {Contingency analyses of memory},
 	Year = {2000}}
@@ -42955,13 +42959,13 @@
 	Year = {2006}}
 
 @incollection{MitcJohn00,
-	Address = {England, {UK}},
+	Address = {New York, {NY}},
 	Author = {K J Mitchell and M K Johnson},
-	Booktitle = {{Oxford} Handbook of Human Memory},
+	Booktitle = {The {Oxford} Handbook of Memory},
 	Editor = {E Tulving and F I M Craik},
-	Pages = {179--185},
+	Pages = {179--196},
 	Publisher = {{Oxford} {University} Press},
-	Title = {Source monitoring: attributing memories to sources},
+	Title = {Source monitoring: attributing mental experiences},
 	Year = {2000}}
 
 @article{HermEtal99,
@@ -54452,3 +54456,39 @@
 	Title = {Dynamic programming algorithm optimization for spoken word recognition},
 	Volume = {26},
 	Year = {1978}}
+
+@article{NadeEtal00,
+	Author = {K Nader and G E Schafe and J E LeDoux},
+	Journal = {Nature},
+	Number = {6797},
+	Pages = {722--726},
+	Title = {Fear memories require protein synthesis in the amygdala for reconsolidation after retrieval},
+	Volume = {406},
+	Year = {2000}}
+
+@article{LifaEtal21,
+	Author = {J Lifanov and J Linde-Domingo and M Wimber},
+	Journal = {Nature Communications},
+	Number = {1},
+	Pages = {3177},
+	Title = {Feature-specific reaction times reveal a semanticisation of memories over time and with repeated remembering},
+	Volume = {12},
+	Year = {2021}}
+
+@article{MeleEtal25,
+	Author = {G Melega and K Samson and H Lee and L Renoult},
+	Journal = {Scientific Reports},
+	Number = {1},
+	Pages = {41987},
+	Title = {The semantic structure of events consistently influences episodic memory recall over time in young and older adults},
+	Volume = {15},
+	Year = {2025}}
+
+@article{FeneEtal25,
+	Author = {C Fenerci and Z Cheng and D R Addis and B Bellana and S Sheldon},
+	Journal = {Trends in Cognitive Sciences},
+	Number = {6},
+	Pages = {516--525},
+	Title = {Studying memory narratives with natural language processing},
+	Volume = {29},
+	Year = {2025}}


### PR DESCRIPTION
Groundwork for the introduction of the memory-dynamics paper. Every value below was verified against CrossRef and publisher-deposited metadata, not copied from an existing reference list.

## Corrections

| Entry | Problem | Fix |
|-|-|-|
| `TianEtal20a` | DOI in the `Volume` field; no number or pages | vol 23, no. 11, pp. 1421–1432 |
| `OwenMann23` → `OwenMann24` | listed as bioRxiv 2023 with a DOI stuffed into `Pages` | *PNAS* 121(35):e2400082121, 2024 |
| `Mann23b` → `Mann24` | published 2024, not 2023; booktitle missing "The Oxford" | *The Oxford Handbook of Human Memory* (Kahana & Wagner, OUP), 2024 |
| `Mann23a` → `Mann23` | becomes the only `Mann23` | suffix dropped per the no-gaps rule |
| `Kaha00` | wrong book, wrong pages, wrong address | *The Oxford Handbook of Memory*, pp. 59–74, New York, {NY} |
| `MitcJohn00` | wrong book, wrong pages, wrong address, wrong title | pp. 179–196, "Source monitoring: attributing mental experiences" |

`Kaha00` and `MitcJohn00` both pointed at "Oxford Handbook of Human Memory", but they are chapters in the **2000 Tulving & Craik** volume, whose title has no "Human". Kahana's page range was listed as 323–384; it is actually 59–74. Both ranges were confirmed contiguous with the adjacent chapters in the same volume (45–58 / **59–74** / 77–92, and 165–178 / **179–196** / 197–212).

## New entries

- `NadeEtal00` — Nader, Schafe & LeDoux, *Nature* 406(6797):722–726
- `LifaEtal21` — Lifanov, Linde-Domingo & Wimber, *Nature Communications* 12(1):3177
- `MeleEtal25` — Melega, Samson, Lee & Renoult, *Scientific Reports* 15(1):41987
- `FeneEtal25` — Fenerci, Cheng, Addis, Bellana & Sheldon, *Trends in Cognitive Sciences* 29(6):516–525

## Breaking changes

Three renames — `OwenMann23`→`OwenMann24`, `Mann23b`→`Mann24`, `Mann23a`→`Mann23`. Any other lab document citing those keys needs updating.

## Validation

`bibcheck/test.py` passes on the whole file: exit 0, 10 checks, no duplicate keys and no duplicate author/title pairs.

## Noted, not fixed

**58 entries still carry a DOI inside `Volume` (20) or `Pages` (38)** — the same defect as `TianEtal20a` and `OwenMann23`, e.g. `ZhanEtal18b`, `WeisEtal16`, `AgraEtal22`, `MehtEtal24`, `WangEtal23`, `JianEtal24`. Left alone here since each needs individual verification and that is a much larger change; worth a dedicated pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)